### PR TITLE
Introduce a pure miniKanren graph apply/reduce relation

### DIFF
--- a/symbolic_pymc/relations/graph.py
+++ b/symbolic_pymc/relations/graph.py
@@ -1,0 +1,97 @@
+from functools import partial
+from unification import var
+
+from kanren import eq
+from kanren.cons import is_cons, is_null
+from kanren.core import condeseq
+from kanren.goals import conso, fail
+
+
+def lapply_anyo(relation, l_in, l_out, i_any=False):
+    """Apply a relation to at least one pair of corresponding elements in two sequences."""
+
+    l_car, l_cdr = var(), var()
+    o_car, o_cdr = var(), var()
+    # o_any = var()
+
+    # We need the `cons` types to match in the end, which involves
+    # using the same `cons`-null (i.e. terminating `cdr`).
+    null_type = None
+    if is_cons(l_out) or is_null(l_out):
+        null_type = type(l_out)()
+    if is_cons(l_in) or is_null(l_in):
+        _null_type = type(l_in)()
+        if null_type is not None and not null_type == _null_type:
+            return fail
+        else:
+            null_type = _null_type
+
+    return (
+        condeseq,
+        [
+            [
+                (conso, l_car, l_cdr, l_in),
+                (conso, o_car, o_cdr, l_out),
+                (
+                    condeseq,
+                    [
+                        [
+                            (relation, l_car, o_car),
+                            # (eq, o_any, True),
+                            (lapply_anyo, relation, l_cdr, o_cdr, True),
+                        ],
+                        [
+                            (eq, l_car, o_car),
+                            # (eq, o_any, i_any),
+                            (lapply_anyo, relation, l_cdr, o_cdr, i_any),
+                        ],
+                    ],
+                ),
+                # (lapply_anyo, relation, l_cdr, o_cdr, o_any),
+            ],
+            [(eq, i_any, True), (eq, l_in, null_type), (eq, l_in, l_out)],
+        ],
+    )
+
+
+def reduceo(relation, in_expr, out_expr):
+    """Relate a term and the fixed-point of that term under a given relation.
+
+    This includes the "identity" relation.
+    """
+    expr_rdcd = var()
+    return (
+        condeseq,
+        [
+            # The fixed-point is another reduction step out.
+            [(relation, in_expr, expr_rdcd), (reduceo, relation, expr_rdcd, out_expr)],
+            # The fixed-point is a single-step reduction.
+            [(relation, in_expr, out_expr)],
+        ],
+    )
+
+
+def graph_applyo(relation, in_graph, out_graph):
+    """Relate the fixed-points of two term-graphs under a given relation."""
+    in_rdc = var()
+    _gapplyo = partial(graph_applyo, relation)
+
+    return (
+        condeseq,
+        [
+            [
+                (relation, in_graph, in_rdc),
+                (
+                    condeseq,
+                    [[(graph_applyo, relation, in_rdc, out_graph)], [(eq, in_rdc, out_graph)]],
+                ),
+            ],
+            [
+                (lapply_anyo, _gapplyo, in_graph, in_rdc),
+                (
+                    condeseq,
+                    [[(graph_applyo, relation, in_rdc, out_graph)], [(eq, in_rdc, out_graph)]],
+                ),
+            ],
+        ],
+    )

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,137 @@
+from operator import add, mul
+from math import log, exp
+
+import pytest
+
+from unification import var
+
+from kanren import run, eq
+from kanren.core import condeseq
+
+from symbolic_pymc.unify import etuple
+from symbolic_pymc.relations.graph import reduceo, lapply_anyo, graph_applyo
+
+
+def reduces(in_expr, out_expr):
+    """Create a relation for a couple math-based identities."""
+    x_lv = var()
+    return (condeseq, [
+        [(eq, in_expr, etuple(add, x_lv, x_lv)),
+         (eq, out_expr, etuple(mul, 2, x_lv))],
+        [(eq, in_expr, etuple(log, etuple(exp, x_lv))),
+         (eq, out_expr, x_lv)],
+    ])
+
+
+def math_reduceo(a, b):
+    """Produce all results for repeated applications of the math-based relation."""
+    return (reduceo, reduces, a, b)
+
+
+def test_lapply_anyo_types():
+    """Make sure that `applyo` preserves the types between its arguments."""
+    q_lv = var()
+    res = run(1, q_lv, (lapply_anyo, lambda x, y: (eq, x, y), [1], q_lv))
+    assert res[0] == [1]
+    res = run(1, q_lv, (lapply_anyo, lambda x, y: (eq, x, y), (1,), q_lv))
+    assert res[0] == (1,)
+    res = run(1, q_lv, (lapply_anyo, lambda x, y: (eq, x, y), etuple(1,), q_lv))
+    assert res[0] == etuple(1,)
+    res = run(1, q_lv, (lapply_anyo, lambda x, y: (eq, x, y), q_lv, (1,)))
+    assert res[0] == (1,)
+    res = run(1, q_lv, (lapply_anyo, lambda x, y: (eq, x, y), q_lv, [1]))
+    assert res[0] == [1]
+    res = run(1, q_lv, (lapply_anyo, lambda x, y: (eq, x, y), q_lv, etuple(1)))
+    assert res[0] == etuple(1)
+
+
+@pytest.mark.parametrize(
+    'test_input, test_output',
+    [([], ()),
+     ([1], ()),
+     ([etuple(add, 1, 1),],
+      ([etuple(mul, 2, 1)],)),
+     ([1, etuple(add, 1, 1)],
+      ([1, etuple(mul, 2, 1)],)),
+     ([etuple(add, 1, 1), 1],
+      ([etuple(mul, 2, 1), 1],)),
+     ([etuple(mul, 2, 1), etuple(add, 1, 1), 1],
+      ([etuple(mul, 2, 1), etuple(mul, 2, 1), 1],)),
+     ([etuple(add, 1, 1), etuple(log, etuple(exp, 5)),],
+      ([etuple(mul, 2, 1), 5],
+       [etuple(add, 1, 1), 5],
+       [etuple(mul, 2, 1), etuple(log, etuple(exp, 5))]))])
+def test_lapply_anyo(test_input, test_output):
+    """Test `lapply_anyo` with fully ground terms (i.e. no logic variables)."""
+    q_lv = var()
+    test_res = run(0, q_lv,
+                   (lapply_anyo, math_reduceo, test_input, q_lv))
+
+    assert len(test_res) == len(test_output)
+
+    # Make sure the first result matches.
+    # TODO: This is fairly implementation-specific (i.e. dependent on the order
+    # in which `condeseq` returns results).
+    if len(test_output) > 0:
+        assert test_res[0] == test_output[0]
+
+    # Make sure all the results match.
+    # TODO: If we want to avoid fixing the output order, convert the lists to
+    # tuples and add everything to a set, then compare.
+    assert test_res == test_output
+
+
+def test_lapply_anyo_reverse():
+    """Test `lapply_anyo` in "reverse" (i.e. specify the reduced form and generate the un-reduced form)."""
+    # Unbounded reverse
+    q_lv = var()
+    rev_input = [etuple(mul, 2, 1)]
+    test_res = run(4, q_lv, (lapply_anyo, reduces, q_lv, rev_input))
+    assert test_res == ([etuple(add, 1, 1)],
+                        [etuple(log, etuple(exp, etuple(mul, 2, 1)))])
+
+    # Guided reverse
+    test_res = run(4, q_lv,
+                   (lapply_anyo, reduces,
+                    [etuple(add, q_lv, 1)],
+                    [etuple(mul, 2, 1)]))
+
+    assert test_res == (1,)
+
+
+@pytest.mark.parametrize(
+    'test_input, test_output',
+    [(1, ()),
+     (etuple(add, 1, 1),
+      (etuple(mul, 2, 1),)),
+     (etuple(add, etuple(mul, 2, 1), etuple(add, 1, 1)),
+      (etuple(mul, 2, etuple(mul, 2, 1)),
+       etuple(add, etuple(mul, 2, 1), etuple(mul, 2, 1)))),
+     (etuple(add, etuple(mul, etuple(log, etuple(exp, 2)), 1), etuple(add, 1, 1)),
+      (etuple(mul, 2, etuple(mul, 2, 1)),
+       etuple(add, etuple(mul, 2, 1), etuple(mul, 2, 1)),
+       etuple(add, etuple(mul, etuple(log, etuple(exp, 2)), 1), etuple(mul, 2, 1)),
+       etuple(add, etuple(mul, 2, 1), etuple(add, 1, 1))))])
+def test_graph_applyo(test_input, test_output):
+    """Test `graph_applyo` with fully ground terms (i.e. no logic variables)."""
+
+    q_lv = var()
+    test_res = run(len(test_output), q_lv,
+                   (graph_applyo, math_reduceo,
+                    test_input, q_lv))
+
+    assert len(test_res) == len(test_output)
+
+    # Make sure the first result matches.
+    if len(test_output) > 0:
+        assert test_res[0] == test_output[0]
+
+    # Make sure all the results match.
+    assert set(test_res) == set(test_output)
+
+
+@pytest.mark.skip('Not ready, yet.')
+def test_graph_applyo_reverse(test_input, test_output):
+    """Test `graph_applyo` in "reverse" (i.e. specify the reduced form and generate the un-reduced form)."""
+    q_lv = var()
+    test_res = run(1, q_lv, (graph_applyo, reduces, q_lv, 5))

--- a/tests/theano/test_opt.py
+++ b/tests/theano/test_opt.py
@@ -1,0 +1,66 @@
+import pytest
+import theano.tensor as tt
+
+from unification import var
+
+from kanren import eq
+from kanren.core import lallgreedy
+
+from theano.gof.opt import EquilibriumOptimizer
+from theano.gof.graph import inputs as tt_inputs
+
+from symbolic_pymc.unify import etuple, tuple_expression
+from symbolic_pymc.theano.meta import mt
+from symbolic_pymc.theano.opt import KanrenRelationSub, FunctionGraph
+from symbolic_pymc.theano.utils import optimize_graph
+
+
+@pytest.mark.usefixtures("run_with_theano")
+def test_kanren_opt():
+    """Make sure we can run miniKanren "optimizations" over a graph until a fixed-point/normal-form is reached.
+    """
+    tt.config.cxx = ''
+    tt.config.compute_test_value = 'ignore'
+
+    x_tt = tt.vector('x')
+    c_tt = tt.vector('c')
+    d_tt = tt.vector('c')
+    A_tt = tt.matrix('A')
+    B_tt = tt.matrix('B')
+
+    Z_tt = A_tt.dot(x_tt + B_tt.dot(c_tt + d_tt))
+
+    fgraph = FunctionGraph(tt_inputs([Z_tt]),
+                           [Z_tt],
+                           clone=True)
+
+    assert isinstance(fgraph.outputs[0].owner.op, tt.Dot)
+
+    def distributes(in_lv, out_lv):
+        return (lallgreedy,
+                # lhs == A * (x + b)
+                (eq, etuple(mt.dot, var('A'),
+                            etuple(mt.add, var('x'), var('b'))),
+                 tuple_expression(in_lv)),
+                # rhs == A * x + A * b
+                (eq, etuple(mt.add,
+                            etuple(mt.dot, var('A'), var('x')),
+                            etuple(mt.dot, var('A'), var('b'))),
+                 out_lv))
+
+    distribute_opt = EquilibriumOptimizer(
+        [KanrenRelationSub(distributes)],
+        max_use_ratio=10)
+
+    fgraph_opt = optimize_graph(fgraph, distribute_opt, return_graph=False)
+
+    assert fgraph_opt.owner.op == tt.add
+    assert isinstance(fgraph_opt.owner.inputs[0].owner.op, tt.Dot)
+    # TODO: Something wrong with `etuple` caching?
+    # assert fgraph_opt.owner.inputs[0].owner.inputs[0] == A_tt
+    assert fgraph_opt.owner.inputs[0].owner.inputs[0].name == 'A'
+    assert fgraph_opt.owner.inputs[1].owner.op == tt.add
+    assert isinstance(fgraph_opt.owner.inputs[1].owner.inputs[0].owner.op,
+                      tt.Dot)
+    assert isinstance(fgraph_opt.owner.inputs[1].owner.inputs[1].owner.op,
+                      tt.Dot)


### PR DESCRIPTION
The added `graph_reduceo` can find fixed-points for reduction relations over graphs in both directions.  This means `graph_reduceo` can find fixed-points for a given graph **and** sequences of graphs satisfying given fixed-points, as well as graphs satisfying "patterns"/relations between those two.

Of course the convergence of `graph_reduceo` depends on the relation and terms its given, but it works for strongly normalizing rewrite rules/relations and that's the baseline requirement for completely replacing&mdash;and going well beyond&mdash;Theano's optimization framework.

The general "search" performance can always be addressed with things like `condp`, or any other adjustments to the `cond*` relations that provide run-of-the-mill controlled graph traversal (e.g. depth-limited or weighed traversal).  See the discussion in #6 for more details.

Otherwise, after adding tests and replacing Theano functions, this closes #6, and, with the addition of a basic collection of graph-normalizing reductions and standard algebraic relations, we should be able to close #5, as well.