### PR TITLE
Remove from_obj and implement dispatcher

### DIFF
--- a/symbolic_pymc/meta.py
+++ b/symbolic_pymc/meta.py
@@ -145,62 +145,6 @@ class MetaSymbol(metaclass=MetaSymbolType):
     def is_meta(cls, obj):
         return isinstance(obj, MetaSymbol) or isvar(obj)
 
-    # @classmethod
-    # def metatize(cls, obj):
-    #     """Create a meta object for a given base object.
-
-    #     XXX: Be careful when overriding this: `isvar` checks are necessary!
-
-    #     """
-    #     print(cls, obj)
-    #     if (
-    #         cls.is_meta(obj)
-    #         or obj is None
-    #         or isinstance(obj, (types.FunctionType, partial, str, dict))
-    #     ):
-    #         return obj
-
-    #     if isinstance(obj, (set, list, tuple, Iterator)):
-    #         # Convert elements of the iterable
-    #         return type(obj)([cls.metatize(o) for o in obj])
-
-    #     if inspect.isclass(obj) and issubclass(obj, cls.base_classes()):
-    #         # This is a class/type covered by a meta class/type.
-    #         try:
-    #             obj_cls = next(filter(lambda t: issubclass(obj, t.base), cls.__subclasses__()))
-    #         except StopIteration:
-    #             # The current class is the best fit.
-    #             if cls.base == obj:
-    #                 return cls
-
-    #             # This object is a subclass of the base type.
-    #             new_type = type(f"Meta{obj.__name__}", (cls,), {"base": obj})
-    #             return new_type(obj)
-    #         else:
-    #             return obj_cls.metatize(obj)
-
-    #     if not isinstance(obj, cls.base_classes()):
-    #         # We might've been given something convertible to a type with a
-    #         # meta type, so let's try that
-    #         try:
-    #             obj = tt.as_tensor_variable(obj)
-    #         except (ValueError, tt.AsTensorError):
-    #             pass
-
-    #         # Check for a meta type again
-    #         if not isinstance(obj, cls.base_classes()):
-    #             raise ValueError("Could not find a MetaSymbol class for {}".format(obj))
-
-    #     try:
-    #         obj_cls = next(filter(lambda t: isinstance(obj, t.base), cls.__subclasses__()))
-    #     except StopIteration:
-    #         res = cls(*[getattr(obj, s) for s in getattr(cls, "__slots__", [])], obj=obj)
-    #     else:
-    #         # Descend into this class to find a more suitable one, if any.
-    #         res = obj_cls.metatize(obj)
-
-    #     return res
-
     def __init__(self, obj=None):
         self.obj = obj
 
@@ -324,14 +268,11 @@ class MetaSymbol(metaclass=MetaSymbolType):
                     p.pretty(obj)
 
 
-# <class 'symbolic_pymc.meta.MetaVariable'>
 @dispatch(type)
 def _metatize(obj):
-
     cls = MetaSymbol
     while True:
         try:
-            # TODO: Go through each meta class and get its base (I need to be able to link it back for ref)
             obj_cls = next(filter(lambda t: issubclass(obj, t.base), cls.__subclasses__()))
         except StopIteration:
             # The current class is the best fit.
@@ -342,21 +283,6 @@ def _metatize(obj):
             return new_type(obj)
         else:
             cls = obj_cls
-
-    # if inspect.isclass(obj) and issubclass(obj, cls.base_classes()):
-    #     # This is a class/type covered by a meta class/type.
-    #     try:
-    #         obj_cls = next(filter(lambda t: issubclass(obj, t.base), cls.__subclasses__()))
-    #     except StopIteration:
-    #         # The current class is the best fit.
-    #         if cls.base == obj:
-    #             return cls
-
-    #         # This object is a subclass of the base type.
-    #         new_type = type(f"Meta{obj.__name__}", (cls,), {"base": obj})
-    #         return new_type(obj)
-    #     else:
-    #         return obj_cls.metatize(obj)
 
 
 @dispatch((MetaSymbol, type(None), types.FunctionType, partial, str, dict))
@@ -691,8 +617,6 @@ class MetaSharedVariable(MetaVariable):
 
     @classmethod
     def _metatize(cls, obj):
-        if isvar(obj):
-            return obj
         res = MetaSharedVariable(
             obj.name, obj.type, obj.container.data, obj.container.strict, obj=obj
         )

--- a/symbolic_pymc/meta.py
+++ b/symbolic_pymc/meta.py
@@ -17,13 +17,39 @@ from unification import var, isvar, Var
 from .rv import RandomVariable
 from .utils import _check_eq
 
-
-# TODO: Replace `from_obj` with a dispatched function?
-# from multipledispatch import dispatch
+from multipledispatch import dispatch
 
 meta_repr = reprlib.Repr()
 meta_repr.maxstring = 100
 meta_repr.maxother = 100
+
+
+def metatize(obj):
+    """Convert object to base type then meta object."""
+    if isvar(obj):
+        return obj
+    return _metatize(obj)
+
+
+@dispatch(object)
+def _metatize(obj):
+    try:
+        obj = tt.as_tensor_variable(obj)
+    except (ValueError, tt.AsTensorError):
+        raise ValueError("Could not find a MetaSymbol class for {}".format(obj))
+    return _metatize(obj)
+
+
+@dispatch((set, list, tuple))
+def _metatize(obj):
+    """Convert elements of an iterable to meta objects."""
+    return type(obj)([metatize(o) for o in obj])
+
+
+@dispatch(Iterator)
+def _metatize(obj):
+    """Convert elements of an iterator to meta objects."""
+    return iter([metatize(o) for o in obj])
 
 
 def _meta_reify_iter(rands):
@@ -78,11 +104,24 @@ class MetaSymbolType(abc.ABCMeta):
 
         clsdict["__setattr__"] = __setattr__
 
-        res = super().__new__(cls, name, bases, clsdict)
+        new_cls = super().__new__(cls, name, bases, clsdict)
+
+        # making sure namespaces are consistent
+        if isinstance(new_cls.base, type):
+            if hasattr(new_cls, "_metatize"):
+                __metatize = new_cls._metatize
+            else:
+
+                def __metatize(obj):
+                    return new_cls(
+                        *[getattr(obj, s) for s in getattr(new_cls, "__slots__", [])], obj=obj
+                    )
+
+            _metatize.add((new_cls.base,), __metatize)
 
         # TODO: Could register base classes.
         # E.g. cls.register(bases)
-        return res
+        return new_cls
 
 
 class MetaSymbol(metaclass=MetaSymbolType):
@@ -91,7 +130,7 @@ class MetaSymbol(metaclass=MetaSymbolType):
     @property
     @abc.abstractmethod
     def base(self):
-        """Return the base type/rator for this meta object."""
+        """Return the underlying (e.g. a theano/tensorflow) base type/rator for this meta object."""
         raise NotImplementedError()
 
     @classmethod
@@ -106,60 +145,61 @@ class MetaSymbol(metaclass=MetaSymbolType):
     def is_meta(cls, obj):
         return isinstance(obj, MetaSymbol) or isvar(obj)
 
-    @classmethod
-    def from_obj(cls, obj):
-        """Create a meta object for a given base object.
+    # @classmethod
+    # def metatize(cls, obj):
+    #     """Create a meta object for a given base object.
 
-        XXX: Be careful when overriding this: `isvar` checks are necessary!
+    #     XXX: Be careful when overriding this: `isvar` checks are necessary!
 
-        """
-        if (
-            cls.is_meta(obj)
-            or obj is None
-            or isinstance(obj, (types.FunctionType, partial, str, dict))
-        ):
-            return obj
+    #     """
+    #     print(cls, obj)
+    #     if (
+    #         cls.is_meta(obj)
+    #         or obj is None
+    #         or isinstance(obj, (types.FunctionType, partial, str, dict))
+    #     ):
+    #         return obj
 
-        if isinstance(obj, (set, list, tuple, Iterator)):
-            # Convert elements of the iterable
-            return type(obj)([cls.from_obj(o) for o in obj])
+    #     if isinstance(obj, (set, list, tuple, Iterator)):
+    #         # Convert elements of the iterable
+    #         return type(obj)([cls.metatize(o) for o in obj])
 
-        if inspect.isclass(obj) and issubclass(obj, cls.base_classes()):
-            # This is a class/type covered by a meta class/type.
-            try:
-                obj_cls = next(filter(lambda t: issubclass(obj, t.base), cls.__subclasses__()))
-            except StopIteration:
-                # The current class is the best fit.
-                if cls.base == obj:
-                    return cls
+    #     if inspect.isclass(obj) and issubclass(obj, cls.base_classes()):
+    #         # This is a class/type covered by a meta class/type.
+    #         try:
+    #             obj_cls = next(filter(lambda t: issubclass(obj, t.base), cls.__subclasses__()))
+    #         except StopIteration:
+    #             # The current class is the best fit.
+    #             if cls.base == obj:
+    #                 return cls
 
-                # This object is a subclass of the base type.
-                new_type = type(f"Meta{obj.__name__}", (cls,), {"base": obj})
-                return new_type(obj)
-            else:
-                return obj_cls.from_obj(obj)
+    #             # This object is a subclass of the base type.
+    #             new_type = type(f"Meta{obj.__name__}", (cls,), {"base": obj})
+    #             return new_type(obj)
+    #         else:
+    #             return obj_cls.metatize(obj)
 
-        if not isinstance(obj, cls.base_classes()):
-            # We might've been given something convertible to a type with a
-            # meta type, so let's try that
-            try:
-                obj = tt.as_tensor_variable(obj)
-            except (ValueError, tt.AsTensorError):
-                pass
+    #     if not isinstance(obj, cls.base_classes()):
+    #         # We might've been given something convertible to a type with a
+    #         # meta type, so let's try that
+    #         try:
+    #             obj = tt.as_tensor_variable(obj)
+    #         except (ValueError, tt.AsTensorError):
+    #             pass
 
-            # Check for a meta type again
-            if not isinstance(obj, cls.base_classes()):
-                raise ValueError("Could not find a MetaSymbol class for {}".format(obj))
+    #         # Check for a meta type again
+    #         if not isinstance(obj, cls.base_classes()):
+    #             raise ValueError("Could not find a MetaSymbol class for {}".format(obj))
 
-        try:
-            obj_cls = next(filter(lambda t: isinstance(obj, t.base), cls.__subclasses__()))
-        except StopIteration:
-            res = cls(*[getattr(obj, s) for s in getattr(cls, "__slots__", [])], obj=obj)
-        else:
-            # Descend into this class to find a more suitable one, if any.
-            res = obj_cls.from_obj(obj)
+    #     try:
+    #         obj_cls = next(filter(lambda t: isinstance(obj, t.base), cls.__subclasses__()))
+    #     except StopIteration:
+    #         res = cls(*[getattr(obj, s) for s in getattr(cls, "__slots__", [])], obj=obj)
+    #     else:
+    #         # Descend into this class to find a more suitable one, if any.
+    #         res = obj_cls.metatize(obj)
 
-        return res
+    #     return res
 
     def __init__(self, obj=None):
         self.obj = obj
@@ -284,13 +324,53 @@ class MetaSymbol(metaclass=MetaSymbolType):
                     p.pretty(obj)
 
 
+# <class 'symbolic_pymc.meta.MetaVariable'>
+@dispatch(type)
+def _metatize(obj):
+
+    cls = MetaSymbol
+    while True:
+        try:
+            # TODO: Go through each meta class and get its base (I need to be able to link it back for ref)
+            obj_cls = next(filter(lambda t: issubclass(obj, t.base), cls.__subclasses__()))
+        except StopIteration:
+            # The current class is the best fit.
+            if cls.base == obj:
+                return cls
+            # This object is a subclass of the base type.
+            new_type = type(f"Meta{obj.__name__}", (obj_cls,), {"base": obj})
+            return new_type(obj)
+        else:
+            cls = obj_cls
+
+    # if inspect.isclass(obj) and issubclass(obj, cls.base_classes()):
+    #     # This is a class/type covered by a meta class/type.
+    #     try:
+    #         obj_cls = next(filter(lambda t: issubclass(obj, t.base), cls.__subclasses__()))
+    #     except StopIteration:
+    #         # The current class is the best fit.
+    #         if cls.base == obj:
+    #             return cls
+
+    #         # This object is a subclass of the base type.
+    #         new_type = type(f"Meta{obj.__name__}", (cls,), {"base": obj})
+    #         return new_type(obj)
+    #     else:
+    #         return obj_cls.metatize(obj)
+
+
+@dispatch((MetaSymbol, type(None), types.FunctionType, partial, str, dict))
+def _metatize(obj):
+    return obj
+
+
 class MetaType(MetaSymbol):
     base = theano.Type
 
     def __call__(self, name=None):
         if self.obj:
-            return MetaSymbol.from_obj(self.obj(name=name))
-        return MetaSymbol.from_obj(self.base.Variable)(self, name)
+            return metatize(self.obj(name=name))
+        return metatize(self.base.Variable)(self, name)
 
 
 class MetaRandomStateType(MetaType):
@@ -377,7 +457,7 @@ class MetaOp(MetaSymbol):
 
         if not op_args_unreified:
             tt_out = self.obj(*op_args)
-            res_var = MetaVariable.from_obj(tt_out)
+            res_var = metatize(tt_out)
 
             if not isinstance(tt_out, (list, tuple)):
                 # If the name is indeterminate, we still want all the reified info,
@@ -481,8 +561,8 @@ class MetaApply(MetaSymbol):
 
     def __init__(self, op, inputs, outputs=None, obj=None):
         super().__init__(obj=obj)
-        self.op = MetaOp.from_obj(op)
-        self.inputs = tuple(MetaSymbol.from_obj(i) for i in inputs)
+        self.op = metatize(op)
+        self.inputs = tuple(metatize(i) for i in inputs)
         self.outputs = outputs
 
     def reify(self):
@@ -518,8 +598,8 @@ class MetaVariable(MetaSymbol):
 
     def __init__(self, type, owner, index, name, obj=None):
         super().__init__(obj=obj)
-        self.type = MetaType.from_obj(type)
-        self.owner = MetaApply.from_obj(owner)
+        self.type = metatize(type)
+        self.owner = metatize(owner)
         self.index = index
         self.name = name
 
@@ -604,17 +684,19 @@ class MetaSharedVariable(MetaVariable):
     base = tt.sharedvar.SharedVariable
     __slots__ = ["name", "type", "data", "strict"]
 
-    @classmethod
-    def from_obj(cls, obj):
-        if isvar(obj):
-            return obj
-        res = cls(obj.name, obj.type, obj.container.data, obj.container.strict, obj=obj)
-        return res
-
     def __init__(self, name, type, data, strict, obj=None):
         super().__init__(type, None, None, name, obj=obj)
         self.data = data
         self.strict = strict
+
+    @classmethod
+    def _metatize(cls, obj):
+        if isvar(obj):
+            return obj
+        res = MetaSharedVariable(
+            obj.name, obj.type, obj.container.data, obj.container.strict, obj=obj
+        )
+        return res
 
 
 class MetaTensorSharedVariable(MetaSharedVariable):
@@ -657,7 +739,7 @@ class MetaAccessor(object):
             self.namespaces = [namespace]
 
     def __call__(self, x):
-        return MetaSymbol.from_obj(x)
+        return metatize(x)
 
     def __getattr__(self, obj):
 
@@ -679,7 +761,7 @@ class MetaAccessor(object):
             def meta_obj(*args, **kwargs):
                 args = [o.reify() if hasattr(o, "reify") else o for o in args]
                 res = ns_obj(*args, **kwargs)
-                return MetaSymbol.from_obj(res)
+                return metatize(res)
 
         elif isinstance(ns_obj, types.ModuleType):
             # It's a sub-module, so let's create another
@@ -687,7 +769,7 @@ class MetaAccessor(object):
             meta_obj = MetaAccessor(namespace=ns_obj)
         else:
             # Hopefully, it's convertible to a meta object...
-            meta_obj = MetaSymbol.from_obj(ns_obj)
+            meta_obj = metatize(ns_obj)
 
         if isinstance(meta_obj, (MetaSymbol, MetaSymbolType, types.FunctionType)):
             setattr(self, obj, meta_obj)
@@ -700,8 +782,7 @@ class MetaAccessor(object):
 
 
 mt = MetaAccessor()
-
-mt.dot = MetaSymbol.from_obj(tt.basic._dot)
+mt.dot = metatize(tt.basic._dot)
 
 
 #

--- a/symbolic_pymc/meta.py
+++ b/symbolic_pymc/meta.py
@@ -270,6 +270,7 @@ class MetaSymbol(metaclass=MetaSymbolType):
 
 @dispatch(type)
 def _metatize(obj):
+    """Return an existing meta type/class, or create a new one."""
     cls = MetaSymbol
     while True:
         try:

--- a/symbolic_pymc/unify.py
+++ b/symbolic_pymc/unify.py
@@ -16,7 +16,7 @@ from kanren.assoccomm import commutative, associative
 from unification.more import unify
 from unification.core import reify, _unify, _reify, Var
 
-from .meta import MetaSymbol, MetaVariable, MetaOp, mt
+from .meta import MetaSymbol, MetaVariable, mt, metatize
 from .utils import _check_eq
 
 tt_class_abstractions = tuple(c.base for c in MetaSymbol.__subclasses__())
@@ -172,16 +172,14 @@ def unify_MetaSymbol(u, v, s):
 
 _unify.add((MetaSymbol, MetaSymbol, dict), unify_MetaSymbol)
 _unify.add(
-    (MetaSymbol, tt_class_abstractions, dict),
-    lambda u, v, s: unify_MetaSymbol(u, MetaSymbol.from_obj(v), s),
+    (MetaSymbol, tt_class_abstractions, dict), lambda u, v, s: unify_MetaSymbol(u, metatize(v), s)
 )
 _unify.add(
-    (tt_class_abstractions, MetaSymbol, dict),
-    lambda u, v, s: unify_MetaSymbol(MetaSymbol.from_obj(u), v, s),
+    (tt_class_abstractions, MetaSymbol, dict), lambda u, v, s: unify_MetaSymbol(metatize(u), v, s)
 )
 _unify.add(
     (tt_class_abstractions, tt_class_abstractions, dict),
-    lambda u, v, s: unify_MetaSymbol(MetaSymbol.from_obj(u), MetaSymbol.from_obj(v), s),
+    lambda u, v, s: unify_MetaSymbol(metatize(u), metatize(v), s),
 )
 
 
@@ -205,7 +203,7 @@ _reify.add((MetaSymbol, dict), _reify_MetaSymbol)
 
 
 def _reify_TheanoClasses(o, s):
-    meta_obj = MetaSymbol.from_obj(o)
+    meta_obj = metatize(o)
     return reify(meta_obj, s)
 
 
@@ -256,7 +254,7 @@ def operator_MetaVariable(x):
 
 operator.add((MetaSymbol,), operator_MetaSymbol)
 operator.add((MetaVariable,), operator_MetaVariable)
-operator.add((tt.Variable,), lambda x: operator(MetaVariable.from_obj(x)))
+operator.add((tt.Variable,), lambda x: operator(metatize(x)))
 
 
 def arguments_MetaSymbol(x):
@@ -291,7 +289,7 @@ def arguments_MetaVariable(x):
 
 arguments.add((MetaSymbol,), arguments_MetaSymbol)
 arguments.add((MetaVariable,), arguments_MetaVariable)
-arguments.add((tt.Variable,), lambda x: arguments(MetaVariable.from_obj(x)))
+arguments.add((tt.Variable,), lambda x: arguments(metatize(x)))
 
 
 def _term_ExpressionTuple(rand, rators):
@@ -300,7 +298,7 @@ def _term_ExpressionTuple(rand, rators):
 
 
 term.add((object, ExpressionTuple), _term_ExpressionTuple)
-term.add((tt.Op, ExpressionTuple), lambda op, args: term(MetaOp.from_obj(op), args))
+term.add((tt.Op, ExpressionTuple), lambda op, args: term(metatize(op), args))
 
 
 @dispatch(object)

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -3,13 +3,13 @@ import theano.tensor as tt
 
 from unification import var
 from symbolic_pymc.meta import (MetaSymbol, MetaTensorVariable, MetaTensorType,
-                                mt)
+                                mt, metatize)
 from symbolic_pymc.utils import graph_equal
 
 
 def test_meta_classes():
     vec_tt = tt.vector('vec')
-    vec_m = MetaSymbol.from_obj(vec_tt)
+    vec_m = metatize(vec_tt)
     assert vec_m.obj == vec_tt
     assert type(vec_m) == MetaTensorVariable
 
@@ -33,8 +33,8 @@ def test_meta_classes():
     assert isinstance(meta_var.owner.inputs[0].obj, tt.TensorConstant)
 
     test_vals = [1, 2.4]
-    meta_vars = MetaSymbol.from_obj(test_vals)
-    assert meta_vars == [MetaSymbol.from_obj(x) for x in test_vals]
+    meta_vars = metatize(test_vals)
+    assert meta_vars == [metatize(x) for x in test_vals]
     # TODO: Do we really want meta variables to be equal to their
     # reified base objects?
     # assert meta_vars == [tt.as_tensor_variable(x) for x in test_vals]


### PR DESCRIPTION
This PR tackles one of the Todo notes in the code by removing from_obj in MetaSymbol and using the multipledispatch library in its place.