### PR TITLE
Fix some issues involving TF `Operation`/`OpDef` names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ nb_tutorials/
 build/*
 dist/*
 *$py.class
+/testing-report.html
+/pip-wheel-metadata/
 
 # C extensions
 *.so
@@ -86,4 +88,3 @@ benchmarks/results/
 .vscode/
 .dmypy.json
 dmypy.json
-/testing-report.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 scipy>=1.2.0
 Theano>=1.0.4
-tf-nightly-2.0-preview>=2.0.0.dev20190526
+tf-nightly-2.0-preview==2.0.0.dev20190606
 tfp-nightly>=0.7.0.dev20190320
 pymc3>=3.6
 pymc4 @ git+https://github.com/pymc-devs/pymc4.git@master#egg=pymc4-0.0.1

--- a/tests/tensorflow/test_unify.py
+++ b/tests/tensorflow/test_unify.py
@@ -8,39 +8,10 @@ from unification import unify, reify, var, variables
 
 from kanren.term import term, operator, arguments
 
-from symbolic_pymc.tensorflow.meta import (TFlowName, mt)
-# from symbolic_pymc.tensorflow.utils import graph_equal
+from symbolic_pymc.tensorflow.meta import (TFlowOpName, mt)
 from symbolic_pymc.unify import (ExpressionTuple, etuple, tuple_expression)
 
 from tests.utils import assert_ops_equal
-
-
-@pytest.mark.usefixtures("run_with_tensorflow")
-def test_unification():
-    a = tf.compat.v1.placeholder(tf.float64, name='a')
-    x_l = var('x_l')
-    a_reif = reify(x_l, {x_l: a})
-    assert a_reif.obj is not None
-    assert a == a_reif.reify()
-
-    test_expr = mt.add(tf.constant(1, dtype=tf.float64),
-                       mt.mul(tf.constant(2, dtype=tf.float64),
-                              x_l))
-    test_reify_res = reify(test_expr, {x_l: a})
-    test_base_res = test_reify_res.reify()
-    assert isinstance(test_base_res, tf.Tensor)
-
-    expected_res = (tf.constant(1, dtype=tf.float64) +
-                    tf.constant(2, dtype=tf.float64) * a)
-    assert_ops_equal(test_base_res, expected_res)
-
-    # from symbolic_pymc.unify import debug_unify; debug_unify()
-
-    meta_expected_res = mt(expected_res)
-    s_test = unify(test_expr, meta_expected_res, {})
-    assert len(s_test) == 5
-
-    assert reify(test_expr, s_test) == meta_expected_res
 
 
 @pytest.mark.usefixtures("run_with_tensorflow")
@@ -67,9 +38,92 @@ def test_etuple_term():
     a_reified = a_evaled.reify()
     assert isinstance(a_reified, tf.Tensor)
     assert a_reified.shape.dims is None
-    assert TFlowName(a_reified.name) == TFlowName(a.name)
+    assert TFlowOpName(a_reified.name) == TFlowOpName(a.name)
 
     e2 = mt.add(a, b)
     e2_et = tuple_expression(e2)
     assert isinstance(e2_et, ExpressionTuple)
     assert e2_et[0] == mt.add
+
+
+@pytest.mark.usefixtures("run_with_tensorflow")
+def test_basic_unify_reify():
+    # Test reification with manually constructed replacements
+    a = tf.compat.v1.placeholder(tf.float64, name='a')
+    x_l = var('x_l')
+    a_reif = reify(x_l, {x_l: a})
+    assert a_reif.obj is not None
+    # Confirm that identity is preserved (i.e. that the underlying object
+    # was properly tracked and not unnecessarily reconstructed)
+    assert a == a_reif.reify()
+
+    test_expr = mt.add(tf.constant(1, dtype=tf.float64),
+                       mt.mul(tf.constant(2, dtype=tf.float64),
+                              x_l))
+    test_reify_res = reify(test_expr, {x_l: a})
+    test_base_res = test_reify_res.reify()
+    assert isinstance(test_base_res, tf.Tensor)
+
+    expected_res = (tf.constant(1, dtype=tf.float64) +
+                    tf.constant(2, dtype=tf.float64) * a)
+    assert_ops_equal(test_base_res, expected_res)
+
+    # Simply make sure that unification succeeds
+    meta_expected_res = mt(expected_res)
+    s_test = unify(test_expr, meta_expected_res, {})
+    assert len(s_test) == 5
+
+    assert reify(test_expr, s_test) == meta_expected_res
+
+
+@pytest.mark.usefixtures("run_with_tensorflow")
+def test_sexp_unify_reify():
+    """Make sure we can unify and reify etuples/S-exps."""
+    # Unify `A . (x + y)`, for `x`, `y` logic variables
+    A = tf.compat.v1.placeholder(tf.float64, name='A',
+                                 shape=tf.TensorShape([None, None]))
+    x = tf.compat.v1.placeholder(tf.float64, name='x',
+                                 shape=tf.TensorShape([None, 1]))
+    y = tf.compat.v1.placeholder(tf.float64, name='y',
+                                 shape=tf.TensorShape([None, 1]))
+
+    z = tf.matmul(A, x + y)
+
+    z_sexp = tuple_expression(z)
+
+    # Let's just be sure that the original TF objects are preserved
+    assert z_sexp[1].eval_obj.reify() == A
+    assert z_sexp[2][1].eval_obj.reify() == x
+    assert z_sexp[2][2].eval_obj.reify() == y
+
+    dis_pat = etuple(mt.matmul, var('A'),
+                     etuple(mt.add, var('b'), var('c'), var()),
+                     # Some op parameters we can ignore...
+                     var(), var(), var())
+
+    s = unify(dis_pat, z_sexp, {})
+
+    assert s[var('A')] == z_sexp[1]
+    assert s[var('b')] == z_sexp[2][1]
+    assert s[var('c')] == z_sexp[2][2]
+
+    # Now, we construct a graph that reflects the distributive property and
+    # reify with the substitutions from the un-distributed form
+    out_pat = etuple(mt.add,
+                     etuple(mt.matmul, var('A'), var('b')),
+                     etuple(mt.matmul, var('A'), var('c')))
+    z_dist = reify(out_pat, s)
+
+    # Evaluate the tuple-expression and get a meta object/graph
+    z_dist_mt = z_dist.eval_obj
+
+    # If all the logic variables were reified, we should be able to
+    # further reify the meta graph and get a concrete TF graph
+    z_dist_tf = z_dist_mt.reify()
+
+    # Check the first part of `A . x + A . y` (i.e. `A . x`)
+    assert z_dist_tf.op.inputs[0].op.inputs[0] == A
+    assert z_dist_tf.op.inputs[0].op.inputs[1] == x
+    # Now, the second, `A . y`
+    assert z_dist_tf.op.inputs[1].op.inputs[0] == A
+    assert z_dist_tf.op.inputs[1].op.inputs[1] == y


### PR DESCRIPTION
`TFMetaOp.name` comparisons are now more based on the underlying `OpDef`'s type/name (i.e. excluding namespace and underscore + number "uniqueness").

Also, the meta namespace-like helper, `TFlowMetaAccessor`/`mt`, now uses a map that accounts for camel-cased operation names (e.g. `mt.matmul` generates a meta object for the `MatMul` `OpDef`).

Overall, these changes make it much easier to create meta graphs/`etuple`/S-exp forms from scratch (e.g. for unification patterns).  See [the new unification test](https://github.com/pymc-devs/symbolic-pymc/pull/24/files#diff-d849a4f99deb234d3cbbee27f42b69faR80) for a complete example.