### PR TITLE
Some improvements to graph and meta object printing

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,3 +12,7 @@ def run_with_tensorflow():
     from symbolic_pymc.tensorflow.meta import load_dispatcher
 
     load_dispatcher()
+
+    # Let's make sure we have a clean graph slate
+    from tensorflow.compat.v1 import reset_default_graph
+    reset_default_graph()

--- a/symbolic_pymc/meta.py
+++ b/symbolic_pymc/meta.py
@@ -17,6 +17,7 @@ from multipledispatch import dispatch
 meta_repr = reprlib.Repr()
 meta_repr.maxstring = 100
 meta_repr.maxother = 100
+meta_repr.print_obj = False
 
 
 def metatize(obj):
@@ -212,7 +213,7 @@ class MetaSymbol(metaclass=MetaSymbolType):
         if obj is None:
             res = self.__repr__()
         else:
-            res = str(obj)
+            res = f"{self.__class__.__name__}({str(obj)})"
         return res
 
     def __repr__(self):
@@ -241,7 +242,7 @@ class MetaSymbol(metaclass=MetaSymbolType):
 
                 obj = getattr(self, "obj", None)
 
-                if obj is not None:
+                if obj is not None and meta_repr.print_obj:
                     if idx is not None:
                         p.text(",")
                         p.breakable()

--- a/symbolic_pymc/tensorflow/meta.py
+++ b/symbolic_pymc/tensorflow/meta.py
@@ -278,6 +278,9 @@ class TFlowMetaOpDef(MetaOp, TFlowMetaSymbol):
 
         return res_var
 
+    def __str__(self):
+        return f"{self.__class__.__name__}({self.obj.name})"
+
     def _repr_pretty_(self, p, cycle):
         return p.text(f"{self.__class__.__name__}({self.obj.name})")
 

--- a/symbolic_pymc/tensorflow/printing.py
+++ b/symbolic_pymc/tensorflow/printing.py
@@ -1,0 +1,63 @@
+import sys
+
+from functools import singledispatch
+from contextlib import contextmanager
+
+import tensorflow as tf
+
+
+class IndentPrinter(object):
+    def __init__(self, formatter):
+        self.formatter = formatter
+        self.indentation = ""
+
+    @contextmanager
+    def indented(self, indent):
+        pre_indentation = self.indentation
+        if isinstance(indent, int):
+            self.indentation += " " * indent
+        else:
+            self.indentation += indent
+        try:
+            yield
+        finally:
+            self.indentation = pre_indentation
+
+    def format(self, obj):
+        return self.indentation + self.formatter(obj)
+
+    def print(self, obj):
+        sys.stdout.write(self.format(obj))
+        sys.stdout.flush()
+
+    def println(self, obj):
+        sys.stdout.write(self.format(obj) + "\n")
+        sys.stdout.flush()
+
+
+@singledispatch
+def tf_dprint(obj, printer=IndentPrinter(str)):
+    """Print a textual representation of a TF graph.
+
+    The output roughly follows the format of `theano.printing.debugprint`.
+    """
+    printer.println(obj)
+
+
+@tf_dprint.register(tf.Tensor)
+def _(obj, printer=IndentPrinter(str)):
+    shape_str = str(obj.shape.as_list())
+    prefix = f'Tensor({obj.op.type}):{obj.value_index},\tshape={shape_str}\t"{obj.name}"'
+    tf_dprint(prefix, printer)
+    if len(obj.op.inputs) > 0:
+        with printer.indented("|  "):
+            tf_dprint(obj.op, printer)
+
+
+@tf_dprint.register(tf.Operation)
+def _(obj, printer=IndentPrinter(str)):
+    prefix = f'Op({obj.type})\t"{obj.name}"'
+    tf_dprint(prefix, printer)
+    with printer.indented("|  "):
+        for op_input in obj.inputs:
+            tf_dprint(op_input, printer)

--- a/symbolic_pymc/theano/meta.py
+++ b/symbolic_pymc/theano/meta.py
@@ -179,6 +179,12 @@ class TheanoMetaOp(MetaOp, TheanoMetaSymbol):
 
         return res_var
 
+    def __str__(self):
+        return f"{self.__class__.__name__}({self.obj})"
+
+    def _repr_pretty_(self, p, cycle):
+        return p.text(f"{self.__class__.__name__}({self.obj})")
+
 
 class TheanoMetaElemwise(TheanoMetaOp):
     base = tt.Elemwise

--- a/symbolic_pymc/unify.py
+++ b/symbolic_pymc/unify.py
@@ -71,7 +71,7 @@ class ExpressionTuple(tuple):
         return res
 
     def __str__(self):
-        return f"e{etuple_repr.repr(tuple(self))}"
+        return f"e({', '.join(tuple(str(i) for i in self))})"
 
     def __repr__(self):
         return f"ExpressionTuple({etuple_repr.repr(tuple(self))})"

--- a/tests/tensorflow/test_printing.py
+++ b/tests/tensorflow/test_printing.py
@@ -1,0 +1,40 @@
+import io
+import textwrap
+
+import pytest
+
+import tensorflow as tf
+
+from contextlib import redirect_stdout
+
+from symbolic_pymc.tensorflow.printing import tf_dprint
+
+
+@pytest.mark.usefixtures("run_with_tensorflow")
+def test_ascii_printing():
+    """Make sure we can ascii/text print a TF graph."""
+
+    A = tf.compat.v1.placeholder(tf.float64, name='A',
+                                 shape=tf.TensorShape([None, None]))
+    x = tf.compat.v1.placeholder(tf.float64, name='x',
+                                 shape=tf.TensorShape([None, 1]))
+    y = tf.compat.v1.placeholder(tf.float64, name='y',
+                                 shape=tf.TensorShape([None, 1]))
+
+    z = tf.matmul(A, tf.add(x, y, name='x_p_y'), name='A_dot')
+
+    std_out = io.StringIO()
+    with redirect_stdout(std_out):
+        tf_dprint(z)
+
+    expected_out = textwrap.dedent('''
+    Tensor(MatMul):0,\tshape=[None, 1]\t"A_dot:0"
+    |  Op(MatMul)\t"A_dot"
+    |  |  Tensor(Placeholder):0,\tshape=[None, None]\t"A:0"
+    |  |  Tensor(Add):0,\tshape=[None, 1]\t"x_p_y:0"
+    |  |  |  Op(Add)\t"x_p_y"
+    |  |  |  |  Tensor(Placeholder):0,\tshape=[None, 1]\t"x:0"
+    |  |  |  |  Tensor(Placeholder):0,\tshape=[None, 1]\t"y:0"
+    ''')
+
+    assert std_out.getvalue() == expected_out.lstrip()


### PR DESCRIPTION
This PR also introduces a simple TensorFlow graph debug printer in the spirit of `theano.printing.debugprint`.