### PR TITLE
Fix TF Shape Printer

### DIFF
--- a/symbolic_pymc/tensorflow/printing.py
+++ b/symbolic_pymc/tensorflow/printing.py
@@ -46,7 +46,10 @@ def tf_dprint(obj, printer=IndentPrinter(str)):
 
 @tf_dprint.register(tf.Tensor)
 def _(obj, printer=IndentPrinter(str)):
-    shape_str = str(obj.shape.as_list())
+    try:
+        shape_str = str(obj.shape.as_list())
+    except ValueError:
+        shape_str = "Unknown"
     prefix = f'Tensor({obj.op.type}):{obj.value_index},\tshape={shape_str}\t"{obj.name}"'
     tf_dprint(prefix, printer)
     if len(obj.op.inputs) > 0:

--- a/tests/tensorflow/test_printing.py
+++ b/tests/tensorflow/test_printing.py
@@ -38,3 +38,18 @@ def test_ascii_printing():
     ''')
 
     assert std_out.getvalue() == expected_out.lstrip()
+
+
+@pytest.mark.usefixtures("run_with_tensorflow")
+def test_unknown_shape():
+    """Make sure we can ascii/text print a TF graph with unknown shapes."""
+
+    A = tf.compat.v1.placeholder(tf.float64, name='A')
+
+    std_out = io.StringIO()
+    with redirect_stdout(std_out):
+        tf_dprint(A)
+
+    expected_out = 'Tensor(Placeholder):0,\tshape=Unknown\t"A:0"\n'
+
+    assert std_out.getvalue() == expected_out.lstrip()


### PR DESCRIPTION
It would throw an exception when shapes were completely unknown.  Now it won't.