### PR TITLE
Fix TFlowMetaTensorShape's use of Dimension objects so that eq is reflexive

### DIFF
--- a/symbolic_pymc/tensorflow/meta.py
+++ b/symbolic_pymc/tensorflow/meta.py
@@ -650,7 +650,7 @@ class TFlowMetaTensorShape(TFlowMetaSymbol):
     def __init__(self, dims, **kwargs):
         self.dims = dims
         if self.dims is not None and not isvar(self.dims):
-            self.dims = tuple(tensor_shape.as_dimension(d) for d in self.dims)
+            self.dims = tuple(tensor_shape.as_dimension(d).value for d in self.dims)
         super().__init__(**kwargs)
 
     @property
@@ -664,12 +664,12 @@ class TFlowMetaTensorShape(TFlowMetaSymbol):
 
     def as_list(self):
         if self.dims is not None and not isvar(self.dims):
-            return [d.value for d in self.dims]
+            return list(self.dims)
         else:
             return self.dims
 
     def __hash__(self):
-        return hash((self.base, tuple(self.as_list())))
+        return hash((self.base, self.dims))
 
 
 class TFlowConstantType(type):

--- a/tests/tensorflow/test_meta.py
+++ b/tests/tensorflow/test_meta.py
@@ -167,6 +167,17 @@ def test_meta_hashing():
 
     assert isinstance(hash(add_mt), int)
 
+
+@pytest.mark.usefixtures("run_with_tensorflow")
+def test_meta_compare():
+    """Make objects compare correctly."""
+
+    a_tf = tf.compat.v1.placeholder('float', name='a', shape=[None, 1])
+    z_tf = tf.multiply(2.0, a_tf)
+
+    assert mt(z_tf) == mt(z_tf)
+
+
 @pytest.mark.usefixtures("run_with_tensorflow")
 def test_meta_multi_output():
     """Make sure we can handle TF `Operation`s that output more than on tensor."""
@@ -233,6 +244,7 @@ def test_meta_distributions():
     Y_mt_tf = Y_mt.reify()
 
     assert_ops_equal(Y_mt, Y_mt_tf)
+
 
 @pytest.mark.usefixtures("run_with_tensorflow")
 def test_inputs_remapping():


### PR DESCRIPTION
`TFlowMetaTensorShape`s were internally using TF `Dimension` objects that were not comparing as expected with `==`.