### PR TITLE
Avoid printing duplicate subgraphs

### DIFF
--- a/tests/tensorflow/test_printing.py
+++ b/tests/tensorflow/test_printing.py
@@ -14,14 +14,13 @@ from symbolic_pymc.tensorflow.printing import tf_dprint
 def test_ascii_printing():
     """Make sure we can ascii/text print a TF graph."""
 
-    A = tf.compat.v1.placeholder(tf.float64, name='A',
+    A = tf.compat.v1.placeholder('float', name='A',
                                  shape=tf.TensorShape([None, None]))
-    x = tf.compat.v1.placeholder(tf.float64, name='x',
+    x = tf.compat.v1.placeholder('float', name='x',
                                  shape=tf.TensorShape([None, 1]))
-    y = tf.compat.v1.placeholder(tf.float64, name='y',
-                                 shape=tf.TensorShape([None, 1]))
+    y = tf.multiply(1.0, x, name='y')
 
-    z = tf.matmul(A, tf.add(x, y, name='x_p_y'), name='A_dot')
+    z = tf.matmul(A, tf.add(y, y, name='x_p_y'), name='A_dot')
 
     std_out = io.StringIO()
     with redirect_stdout(std_out):
@@ -33,8 +32,12 @@ def test_ascii_printing():
     |  |  Tensor(Placeholder):0,\tshape=[None, None]\t"A:0"
     |  |  Tensor(Add):0,\tshape=[None, 1]\t"x_p_y:0"
     |  |  |  Op(Add)\t"x_p_y"
-    |  |  |  |  Tensor(Placeholder):0,\tshape=[None, 1]\t"x:0"
-    |  |  |  |  Tensor(Placeholder):0,\tshape=[None, 1]\t"y:0"
+    |  |  |  |  Tensor(Mul):0,	shape=[None, 1]	"y:0"
+    |  |  |  |  |  Op(Mul)\t"y"
+    |  |  |  |  |  |  Tensor(Const):0,\tshape=[]\t"y/x:0"
+    |  |  |  |  |  |  Tensor(Placeholder):0,\tshape=[None, 1]\t"x:0"
+    |  |  |  |  Tensor(Mul):0,\tshape=[None, 1]\t"y:0"
+    |  |  |  |  |  ...
     ''')
 
     assert std_out.getvalue() == expected_out.lstrip()


### PR DESCRIPTION
These changes will cause `tf_dprint` to only print unique subgraphs once.