### PR TITLE
Make graph relations yield results in both directions and all cases

### DIFF
--- a/symbolic_pymc/relations/graph.py
+++ b/symbolic_pymc/relations/graph.py
@@ -1,59 +1,99 @@
 from functools import partial
-from unification import var
+from unification import var, isvar
+
+from unification import reify
+from kanren.core import goaleval
 
 from kanren import eq
 from kanren.cons import is_cons, is_null
-from kanren.core import condeseq
+from kanren.core import conde, lall
 from kanren.goals import conso, fail
 
-from ..etuple import etuplize
+from ..etuple import etuplize, etuple
 
 
-def lapply_anyo(relation, l_in, l_out, i_any=False):
-    """Apply a relation to at least one pair of corresponding elements in two sequences."""
+def lapply_anyo(relation, l_in, l_out, null_type=False):
+    """Apply a relation to at least one pair of corresponding elements in two sequences.
 
-    l_car, l_cdr = var(), var()
-    o_car, o_cdr = var(), var()
-    # o_any = var()
+    Parameters
+    ----------
+    null_type: optional
+       An object that's a valid cdr for the collection type desired.  If
+       `False` (i.e. the default value), the cdr will be inferred from the
+       inputs, or defaults to an empty list.
+    """
 
-    # We need the `cons` types to match in the end, which involves
-    # using the same `cons`-null (i.e. terminating `cdr`).
-    null_type = None
-    if is_cons(l_out) or is_null(l_out):
-        null_type = type(l_out)()
-    if is_cons(l_in) or is_null(l_in):
-        _null_type = type(l_in)()
-        if null_type is not None and not null_type == _null_type:
-            return fail
-        else:
-            null_type = _null_type
+    def _lapply_anyo(relation, l_in, l_out, i_any, null_type):
+        def _goal(s):
 
-    return (
-        condeseq,
-        [
-            [
-                (conso, l_car, l_cdr, l_in),
-                (conso, o_car, o_cdr, l_out),
-                (
-                    condeseq,
-                    [
-                        [
-                            (relation, l_car, o_car),
-                            # (eq, o_any, True),
-                            (lapply_anyo, relation, l_cdr, o_cdr, True),
-                        ],
-                        [
-                            (eq, l_car, o_car),
-                            # (eq, o_any, i_any),
-                            (lapply_anyo, relation, l_cdr, o_cdr, i_any),
-                        ],
-                    ],
-                ),
-                # (lapply_anyo, relation, l_cdr, o_cdr, o_any),
-            ],
-            [(eq, i_any, True), (eq, l_in, null_type), (eq, l_in, l_out)],
-        ],
-    )
+            nonlocal i_any, null_type
+
+            l_in_rf, l_out_rf = reify((l_in, l_out), s)
+
+            i_car, i_cdr = var(), var()
+            o_car, o_cdr = var(), var()
+
+            conde_branches = []
+            if i_any or (isvar(l_in_rf) and isvar(l_out_rf)):
+                conde_branches.append([eq(l_in_rf, null_type), eq(l_in_rf, l_out_rf)])
+
+            descend_branch = [
+                goaleval(conso(i_car, i_cdr, l_in_rf)),
+                goaleval(conso(o_car, o_cdr, l_out_rf)),
+            ]
+
+            conde_branches.append(descend_branch)
+
+            conde_2_branches = [
+                [eq(i_car, o_car), _lapply_anyo(relation, i_cdr, o_cdr, i_any, null_type)]
+            ]
+
+            conde_2_branches.append(
+                [relation(i_car, o_car), _lapply_anyo(relation, i_cdr, o_cdr, True, null_type)]
+            )
+
+            descend_branch.append(conde(*conde_2_branches))
+
+            g = conde(*conde_branches)
+            g = goaleval(g)
+
+            yield from g(s)
+
+        return _goal
+
+    def goal(s, null_type=null_type):
+
+        # We need the `cons` types to match in the end, which involves
+        # using the same `cons`-null (i.e. terminating `cdr`).
+        if null_type is False:
+            l_out_, l_in_ = reify((l_out, l_in), s)
+
+            out_null_type = False
+            if is_cons(l_out_) or is_null(l_out_):
+                out_null_type = type(l_out_)()
+
+            in_null_type = False
+            if is_cons(l_in_) or is_null(l_in_):
+                in_null_type = type(l_in_)()
+
+                if out_null_type is not False and not type(in_null_type) == type(out_null_type):
+                    yield from fail(s)
+                    return
+
+            null_type = (
+                out_null_type
+                if out_null_type is not False
+                else in_null_type
+                if in_null_type is not False
+                else []
+            )
+
+        g = _lapply_anyo(relation, l_in, l_out, False, null_type)
+        g = goaleval(g)
+
+        yield from g(s)
+
+    return goal
 
 
 def reduceo(relation, in_expr, out_expr):
@@ -62,18 +102,17 @@ def reduceo(relation, in_expr, out_expr):
     This includes the "identity" relation.
     """
     expr_rdcd = var()
-    return (
-        condeseq,
-        [
-            # The fixed-point is another reduction step out.
-            [(relation, in_expr, expr_rdcd), (reduceo, relation, expr_rdcd, out_expr)],
-            # The fixed-point is a single-step reduction.
-            [(relation, in_expr, out_expr)],
-        ],
+    return conde(
+        # The fixed-point is another reduction step out.
+        [(relation, in_expr, expr_rdcd), (reduceo, relation, expr_rdcd, out_expr)],
+        # The fixed-point is a single-step reduction.
+        [(relation, in_expr, out_expr)],
     )
 
 
-def graph_applyo(relation, in_graph, out_graph, preprocess_graph=partial(etuplize, shallow=True)):
+def graph_applyo(
+    relation, in_graph, out_graph, preprocess_graph=partial(etuplize, shallow=True), inside=False
+):
     """Relate the fixed-points of two term-graphs under a given relation.
 
     Parameters
@@ -84,30 +123,79 @@ def graph_applyo(relation, in_graph, out_graph, preprocess_graph=partial(etupliz
       The graph for which the left-hand side of a binary relation holds.
     out_graph: object
       The graph for which the right-hand side of a binary relation holds.
-    preprocess_graph: callable
+    preprocess_graph: callable (optional)
       A unary function that produces an iterable upon which `lapply_anyo`
       can be applied in order to traverse a graph's subgraphs.  The default
       function converts the graph to expression-tuple form.
+    inside: boolean (optional)
+      Process the graph or sub-graphs first.
     """
-    in_rdc = var()
 
     if preprocess_graph in (False, None):
 
         def preprocess_graph(x):
             return x
 
-    _gapplyo = partial(graph_applyo, relation, preprocess_graph=preprocess_graph)
+    def _gapplyo(s):
 
-    return (
-        condeseq,
-        [
-            [
-                (relation, in_graph, in_rdc),
-                (condeseq, [[(_gapplyo, in_rdc, out_graph)], [(eq, in_rdc, out_graph)]]),
-            ],
-            [
-                (lapply_anyo, _gapplyo, preprocess_graph(in_graph), in_rdc),
-                (condeseq, [[(_gapplyo, in_rdc, out_graph)], [(eq, in_rdc, out_graph)]]),
-            ],
-        ],
-    )
+        nonlocal in_graph, out_graph, inside
+
+        in_rdc = var()
+
+        in_graph_rf, out_graph_rf = reify((in_graph, out_graph), s)
+
+        expanding = isvar(in_graph_rf)
+
+        _gapply = partial(
+            graph_applyo,
+            relation,
+            preprocess_graph=preprocess_graph,
+            inside=inside,  # expanding and (True ^ inside)
+        )
+
+        # This goal reduces the entire graph
+        graph_reduce_gl = (relation, in_graph_rf, in_rdc)
+
+        # This goal reduces children/arguments of the graph
+        subgraphs_reduce_gl = lapply_anyo(
+            _gapply,
+            preprocess_graph(in_graph_rf),
+            in_rdc,
+            null_type=etuple() if expanding else False,
+        )
+
+        # Take only one step (e.g. reduce the entire graph and/or its
+        # arguments)
+        reduce_once_gl = eq(in_rdc, out_graph_rf)
+
+        # Take another reduction step on top of the one(s) we already did
+        # (i.e. recurse)
+        reduce_again_gl = _gapply(in_rdc, out_graph_rf)
+
+        # We want the fixed-point value first, but that requires
+        # some checks.
+        if expanding:
+            # When the un-reduced expression is a logic variable (i.e. we're
+            # "expanding" expressions), we can't go depth first.
+            # We need to draw the association between (i.e. unify) the reduced
+            # and expanded expressions ASAP, in order to produce finite
+            # expanded graphs first and yield results.
+            g = conde(
+                [reduce_once_gl, graph_reduce_gl],
+                [reduce_again_gl, graph_reduce_gl],
+                [reduce_once_gl, subgraphs_reduce_gl],
+                [reduce_again_gl, subgraphs_reduce_gl],
+            )
+        else:
+            # TODO: With an explicit simplification order, could we determine
+            # whether or not simplifying the sub-expressions or the expression
+            # itself is more efficient?
+            g = lall(
+                conde([graph_reduce_gl], [subgraphs_reduce_gl]),
+                conde([reduce_again_gl], [reduce_once_gl]),
+            )
+
+        g = goaleval(g)
+        yield from g(s)
+
+    return _gapplyo

--- a/symbolic_pymc/relations/theano/__init__.py
+++ b/symbolic_pymc/relations/theano/__init__.py
@@ -3,10 +3,10 @@ from functools import partial
 from unification import var
 
 from kanren import eq
-from kanren.core import lallgreedy
+from kanren.core import lall
 
 from .linalg import buildo
-from ..graph import graph_applyo
+from ..graph import graph_applyo, lapply_anyo
 from ...etuple import etuplize, etuple
 from ...theano.meta import mt
 
@@ -63,13 +63,15 @@ def non_obs_graph_applyo(relation, a, b):
     obs_lv, obs_rv_lv = var(), var()
     rv_op_lv, rv_args_lv, obs_rv_lv = var(), var(), var()
     new_rv_args_lv, new_obs_rv_lv = var(), var()
-    return lallgreedy(
+    return lall(
         # Indicate the observed term (i.e. observation and RV)
         eq(a, mt.observed(obs_lv, obs_rv_lv)),
         # Deconstruct the observed random variable
         (buildo, rv_op_lv, rv_args_lv, obs_rv_lv),
         # Apply relation to the RV's inputs
-        (relation, rv_args_lv, new_rv_args_lv),
+        lapply_anyo(
+            lambda x, y: tt_graph_applyo(relation, x, y), rv_args_lv, new_rv_args_lv, skip_op=False
+        ),
         # Reconstruct the random variable
         (buildo, rv_op_lv, new_rv_args_lv, new_obs_rv_lv),
         # Reconstruct the observation

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -3,24 +3,59 @@ from math import log, exp
 
 import pytest
 
-from unification import var
+from unification import var, unify
 
-from kanren import run, eq
-from kanren.core import condeseq
+from kanren import run, eq, conde, lall
+from kanren.goals import isinstanceo
 
-from symbolic_pymc.etuple import etuple
+from symbolic_pymc.etuple import etuple, ExpressionTuple
 from symbolic_pymc.relations.graph import reduceo, lapply_anyo, graph_applyo
+
+
+class OrderedFunction(object):
+
+    def __init__(self, func):
+        self.func = func
+
+    def __call__(self, *args, **kwargs):
+        return self.func(*args, **kwargs)
+
+    @property
+    def __name__(self):
+        return self.func.__name__
+
+    def __lt__(self, other):
+        return self.__name__ < getattr(other, '__name__', str(other))
+
+    def __gt__(self, other):
+        return self.__name__ > getattr(other, '__name__', str(other))
+
+    def __repr__(self):
+        return self.__name__
+
+
+add = OrderedFunction(add)
+mul = OrderedFunction(mul)
+log = OrderedFunction(log)
+exp = OrderedFunction(exp)
+
+
+ExpressionTuple.__lt__ = lambda self, other: self < (other,) if isinstance(other, int) else tuple(self) < tuple(other)
+ExpressionTuple.__gt__ = lambda self, other: self > (other,) if isinstance(other, int) else tuple(self) > tuple(other)
 
 
 def reduces(in_expr, out_expr):
     """Create a relation for a couple math-based identities."""
     x_lv = var()
-    return (condeseq, [
-        [(eq, in_expr, etuple(add, x_lv, x_lv)),
-         (eq, out_expr, etuple(mul, 2, x_lv))],
-        [(eq, in_expr, etuple(log, etuple(exp, x_lv))),
-         (eq, out_expr, x_lv)],
-    ])
+    x_lv.token = f'x{x_lv.token}'
+
+    return (lall,
+            conde([eq(in_expr, etuple(add, x_lv, x_lv)),
+                   eq(out_expr, etuple(mul, 2, x_lv))],
+                  [eq(in_expr, etuple(log, etuple(exp, x_lv))),
+                   eq(out_expr, x_lv)]),
+            conde([(isinstanceo, [in_expr, (float, int, ExpressionTuple)], True)],
+                  [(isinstanceo, [out_expr, (float, int, ExpressionTuple)], True)]))
 
 
 def math_reduceo(a, b):
@@ -31,18 +66,24 @@ def math_reduceo(a, b):
 def test_lapply_anyo_types():
     """Make sure that `applyo` preserves the types between its arguments."""
     q_lv = var()
-    res = run(1, q_lv, (lapply_anyo, lambda x, y: (eq, x, y), [1], q_lv))
+    res = run(1, q_lv, lapply_anyo(lambda x, y: eq(x, y), [1], q_lv))
     assert res[0] == [1]
-    res = run(1, q_lv, (lapply_anyo, lambda x, y: (eq, x, y), (1,), q_lv))
+    res = run(1, q_lv, lapply_anyo(lambda x, y: eq(x, y), (1,), q_lv))
     assert res[0] == (1,)
-    res = run(1, q_lv, (lapply_anyo, lambda x, y: (eq, x, y), etuple(1,), q_lv))
+    res = run(1, q_lv, lapply_anyo(lambda x, y: eq(x, y), etuple(1,), q_lv))
     assert res[0] == etuple(1,)
-    res = run(1, q_lv, (lapply_anyo, lambda x, y: (eq, x, y), q_lv, (1,)))
+    res = run(1, q_lv, lapply_anyo(lambda x, y: eq(x, y), q_lv, (1,)))
     assert res[0] == (1,)
-    res = run(1, q_lv, (lapply_anyo, lambda x, y: (eq, x, y), q_lv, [1]))
+    res = run(1, q_lv, lapply_anyo(lambda x, y: eq(x, y), q_lv, [1]))
     assert res[0] == [1]
-    res = run(1, q_lv, (lapply_anyo, lambda x, y: (eq, x, y), q_lv, etuple(1)))
+    res = run(1, q_lv, lapply_anyo(lambda x, y: eq(x, y), q_lv, etuple(1)))
     assert res[0] == etuple(1)
+    res = run(1, q_lv, lapply_anyo(lambda x, y: eq(x, y), [1, 2], [1, 2]))
+    assert len(res) == 1
+    res = run(1, q_lv, lapply_anyo(lambda x, y: eq(x, y), [1, 2], [1, 3]))
+    assert len(res) == 0
+    res = run(1, q_lv, lapply_anyo(lambda x, y: eq(x, y), [1, 2], (1, 2)))
+    assert len(res) == 0
 
 
 @pytest.mark.parametrize(
@@ -69,6 +110,8 @@ def test_lapply_anyo(test_input, test_output):
 
     assert len(test_res) == len(test_output)
 
+    test_res = sorted(test_res)
+    test_output = sorted(test_output)
     # Make sure the first result matches.
     # TODO: This is fairly implementation-specific (i.e. dependent on the order
     # in which `condeseq` returns results).
@@ -122,6 +165,9 @@ def test_graph_applyo(test_input, test_output):
 
     assert len(test_res) == len(test_output)
 
+    test_res = sorted(test_res)
+    test_output = sorted(test_output)
+
     # Make sure the first result matches.
     if len(test_output) > 0:
         assert test_res[0] == test_output[0]
@@ -130,8 +176,50 @@ def test_graph_applyo(test_input, test_output):
     assert set(test_res) == set(test_output)
 
 
-@pytest.mark.skip('Not ready, yet.')
-def test_graph_applyo_reverse(test_input, test_output):
+def test_graph_applyo_reverse():
     """Test `graph_applyo` in "reverse" (i.e. specify the reduced form and generate the un-reduced form)."""
-    q_lv = var()
-    test_res = run(1, q_lv, (graph_applyo, reduces, q_lv, 5))
+    q_lv = var('q')
+
+    test_res = run(2, q_lv, graph_applyo(reduces, q_lv, 5))
+    assert test_res == (etuple(log, etuple(exp, 5)),
+                        etuple(log, etuple(exp, etuple(log, etuple(exp, 5)))))
+    assert all(e.eval_obj == 5.0 for e in test_res)
+
+    # Make sure we get some variety in the results
+    test_res = run(3, q_lv, graph_applyo(reduces, q_lv, etuple(mul, 2, 5)))
+    assert test_res == (
+        # Expansion of the term's root
+        etuple(add, 5, 5),
+        # Two step expansion at the root
+        etuple(log, etuple(exp, etuple(add, 5, 5))),
+        # Expansion into a sub-term
+        etuple(mul, 2, etuple(log, etuple(exp, 5)))
+    )
+    assert all(e.eval_obj == 10.0 for e in test_res)
+
+    r_lv = var('r')
+    test_res = run(4, [q_lv, r_lv], graph_applyo(reduces, q_lv, r_lv))
+    expect_res = ([etuple(add, 1, 1), etuple(mul, 2, 1)],
+                  [etuple(log, etuple(exp, etuple(add, 1, 1))), etuple(mul, 2, 1)],
+                  [etuple(), etuple()],
+                  [etuple(add, etuple(mul, 2, 1), etuple(add, 1, 1)),
+                   etuple(mul, 2, etuple(mul, 2, 1))])
+    assert list(unify(a1, a2) and unify(b1, b2)
+                for [a1, b1], [a2, b2] in zip(test_res, expect_res))
+
+
+def test_lapply_scratch():
+    q_lv = var('q')
+    assert len(run(4, q_lv, lapply_anyo(reduces, [etuple(mul, 2, var('x'))], q_lv))) == 0
+
+    test_res = run(4, q_lv, lapply_anyo(reduces, [etuple(add, 2, 2), 1], q_lv))
+    assert test_res == ([etuple(mul, 2, 2), 1],)
+
+    test_res = run(4, q_lv, lapply_anyo(reduces, [1, etuple(add, 2, 2)], q_lv))
+    assert test_res == ([1, etuple(mul, 2, 2)],)
+
+    test_res = run(4, q_lv, lapply_anyo(reduces, q_lv, var('z')))
+    assert all(isinstance(r, list) for r in test_res)
+
+    test_res = run(4, q_lv, lapply_anyo(reduces, q_lv, var('z'), tuple()))
+    assert all(isinstance(r, tuple) for r in test_res)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -70,13 +70,13 @@ def test_lapply_anyo_types():
     assert res[0] == [1]
     res = run(1, q_lv, lapply_anyo(lambda x, y: eq(x, y), (1,), q_lv))
     assert res[0] == (1,)
-    res = run(1, q_lv, lapply_anyo(lambda x, y: eq(x, y), etuple(1,), q_lv))
+    res = run(1, q_lv, lapply_anyo(lambda x, y: eq(x, y), etuple(1,), q_lv, skip_op=False))
     assert res[0] == etuple(1,)
     res = run(1, q_lv, lapply_anyo(lambda x, y: eq(x, y), q_lv, (1,)))
     assert res[0] == (1,)
     res = run(1, q_lv, lapply_anyo(lambda x, y: eq(x, y), q_lv, [1]))
     assert res[0] == [1]
-    res = run(1, q_lv, lapply_anyo(lambda x, y: eq(x, y), q_lv, etuple(1)))
+    res = run(1, q_lv, lapply_anyo(lambda x, y: eq(x, y), q_lv, etuple(1), skip_op=False))
     assert res[0] == etuple(1)
     res = run(1, q_lv, lapply_anyo(lambda x, y: eq(x, y), [1, 2], [1, 2]))
     assert len(res) == 1
@@ -84,6 +84,10 @@ def test_lapply_anyo_types():
     assert len(res) == 0
     res = run(1, q_lv, lapply_anyo(lambda x, y: eq(x, y), [1, 2], (1, 2)))
     assert len(res) == 0
+    res = run(0, q_lv, lapply_anyo(lambda x, y: eq(y, etuple(mul, 2, x)),
+                                   etuple(add, 1, 2), q_lv, skip_op=True))
+    assert len(res) == 3
+    assert all(r[0] == add for r in res)
 
 
 @pytest.mark.parametrize(

--- a/tests/theano/test_relations.py
+++ b/tests/theano/test_relations.py
@@ -36,9 +36,7 @@ def test_pymc_normals():
 
     graph_mt = mt(radon_like_rv)
     expr_graph, = run(1, var('q'),
-                      non_obs_graph_applyo(
-                          lambda x, y: tt_graph_applyo(scale_loc_transform, x, y),
-                          graph_mt, var('q')))
+                      non_obs_graph_applyo(scale_loc_transform, graph_mt, var('q')))
 
     radon_like_rv_opt = expr_graph.reify()
 


### PR DESCRIPTION
This is a fix for #26, and possibly a start toward more efficient relational graph traversal.

## Examples
```python
from math import log, exp
from operator import add, mul

from unification import var

from kanren import run, eq, conde

from symbolic_pymc.etuple import etuple, ExpressionTuple
from symbolic_pymc.relations.graph import graph_applyo


# Just some nice formatting
def etuple_str(self):
    if len(self) > 0:
        return f"{getattr(self[0], '__name__', self[0])}({', '.join(map(str, self[1:]))})"
    else:
        return 'noop'

ExpressionTuple.__str__ = etuple_str
del ExpressionTuple._repr_pretty_


def math_reduceo(expanded_term, reduced_term):
    """Construct a goal for some simple math reductions."""
    # Create a logic variable to represent our variable term "x"
    x_lv = var()
    # `conde` is a relational version of Lisp's `cond`/if-else; here, each
    # "branch" pairs the right- and left-hand sides of a replacement rule with
    # the corresponding inputs.
    return conde(
                # add(x, x) -> mul(2, x)
                [eq(expanded_term, etuple(add, x_lv, x_lv)),
                 eq(reduced_term, etuple(mul, 2, x_lv))],
                # log(exp(x)) -> x
                [eq(expanded_term, etuple(log, etuple(exp, x_lv))),
                 eq(reduced_term, x_lv)])

```
### Reductions

This example is a very straight-forward reduction of `add(etuple(add, 3, 3), exp(log(exp(5))))` under our implemented rules.
```python
# Create a logic variable to represent the results we want to compute
q_lv = var('q')

expanded_term = etuple(add, etuple(add, 3, 3), etuple(exp, etuple(log, etuple(exp, 5))))
reduced_term = q_lv

# Asking for 0 results means all results
res = run(0, q_lv, graph_applyo(math_reduceo, expanded_term, reduced_term))
```
```python
>>> print('\n'.join((f'{expanded_term} == {r}' for r in res)))
add(add(3, 3), exp(log(exp(5)))) == add(mul(2, 3), exp(5))
add(add(3, 3), exp(log(exp(5)))) == add(add(3, 3), exp(5))
add(add(3, 3), exp(log(exp(5)))) == add(mul(2, 3), exp(log(exp(5))))
```

### Expansions
In this example, we're specifying a "concrete" reduced term (i.e. `mul(2, 5)`) and an "unknown" expanded term (i.e. the logic variable `q_lv`).  We're essentially asking for graphs that would reduce to `mul(2, 5)`.
```python
expanded_term = q_lv
reduced_term = etuple(mul, 2, 5)

# Ask for 10 results of `q_lv`
res = run(10, q_lv, graph_applyo(math_reduceo, expanded_term, reduced_term))
```
```python
>>> rjust = max(map(lambda x: len(str(x)), res))
>>> print('\n'.join((f'{str(r):>{rjust}} == {reduced_term}' for r in res)))
                    add(5, 5) == mul(2, 5)
          log(exp(add(5, 5))) == mul(2, 5)
          mul(2, log(exp(5))) == mul(2, 5)
          add(5, log(exp(5))) == mul(2, 5)
          log(exp(mul(2, 5))) == mul(2, 5)
log(exp(log(exp(add(5, 5))))) == mul(2, 5)
          mul(log(exp(2)), 5) == mul(2, 5)
log(log(exp(exp(add(5, 5))))) == mul(2, 5)
add(log(exp(5)), log(exp(5))) == mul(2, 5)
mul(2, log(exp(log(exp(5))))) == mul(2, 5)
```

### Expansions _and_ Reductions
Now, we set both terms to "unknowns".
```python
expanded_term = q_lv
reduced_term = var('r')

res = run(10, [expanded_term, reduced_term],
          graph_applyo(math_reduceo, expanded_term, reduced_term))
```
```python
>>> rjust = max(map(lambda x: len(str(x[0])), res))
>>> print('\n'.join((f'{str(e):>{rjust}} == {str(r)}' for e, r in res)))
                     add(~_3289, ~_3289) == mul(2, ~_3289)
           log(exp(add(~_3293, ~_3293))) == mul(2, ~_3293)
                                    noop == noop
add(mul(2, ~_3320), add(~_3320, ~_3320)) == mul(2, mul(2, ~_3320))
                        log(exp(~_3289)) == ~_3289
 log(exp(log(exp(add(~_3328, ~_3328))))) == mul(2, ~_3328)
                                ~_3297() == ~_3297()
 log(log(exp(exp(add(~_3338, ~_3338))))) == mul(2, ~_3338)
                          log(exp(noop)) == noop
                          ~_3297(~_3333) == ~_3297(~_3333)
```
The symbols prefixed by `~` are logic variables, so a result like `add(~_3289, ~3289)` basically means `add(x, x)` for some variable `x`.