### PR TITLE
Remove the need to disable eager-mode globally

### DIFF
--- a/symbolic_pymc/tensorflow/__init__.py
+++ b/symbolic_pymc/tensorflow/__init__.py
@@ -1,6 +1,2 @@
-from tensorflow.python.framework import ops
-
 # Needed to register generic functions
 from .unify import *
-
-ops.disable_eager_execution()

--- a/symbolic_pymc/tensorflow/printing.py
+++ b/symbolic_pymc/tensorflow/printing.py
@@ -47,6 +47,16 @@ def tf_dprint(obj, printer=None):
 
     The output roughly follows the format of `theano.printing.debugprint`.
     """
+    if isinstance(obj, tf.Tensor):
+        try:
+            obj.op
+        except AttributeError:
+            raise ValueError(
+                f"TensorFlow Operation not available; "
+                "try recreating the object with eager-mode disabled"
+                " (e.g. within `tensorflow.python.eager.context.graph_mode`)"
+            )
+
     if printer is None:
         printer = TFlowPrinter(str, sys.stdout)
 

--- a/tests/tensorflow/__init__.py
+++ b/tests/tensorflow/__init__.py
@@ -1,0 +1,10 @@
+from functools import wraps
+from tensorflow.python.eager.context import graph_mode
+
+
+def run_in_graph_mode(f):
+    @wraps(f)
+    def _f(*args, **kwargs):
+        with graph_mode():
+            return f()
+    return _f

--- a/tests/tensorflow/test_meta.py
+++ b/tests/tensorflow/test_meta.py
@@ -3,6 +3,7 @@ import numpy as np
 
 import tensorflow as tf
 
+from tensorflow.python.eager.context import graph_mode
 from tensorflow_probability import distributions as tfd
 
 from unification import var, isvar
@@ -17,6 +18,7 @@ from symbolic_pymc.tensorflow.meta import (TFlowMetaTensor,
                                            TFlowOpName,
                                            mt)
 
+from tests.tensorflow import run_in_graph_mode
 from tests.tensorflow.utils import assert_ops_equal
 
 
@@ -50,6 +52,29 @@ def test_meta_helper():
 
 
 @pytest.mark.usefixtures("run_with_tensorflow")
+def test_meta_eager():
+
+    assert tf.executing_eagerly()
+
+    N = 100
+    X = np.vstack([np.random.randn(N), np.ones(N)]).T
+    X_tf = tf.convert_to_tensor(X)
+
+    with pytest.raises(ValueError):
+        _ = mt(X_tf)
+
+    with pytest.raises(ValueError):
+        _ = mt(X)
+
+    with graph_mode():
+        N = 100
+        X = np.vstack([np.random.randn(N), np.ones(N)]).T
+        X_tf = tf.convert_to_tensor(X)
+        _ = mt(X_tf)
+
+
+@pytest.mark.usefixtures("run_with_tensorflow")
+@run_in_graph_mode
 def test_meta_create():
     N = 100
     X = np.vstack([np.random.randn(N), np.ones(N)]).T
@@ -157,6 +182,7 @@ def test_meta_lvars():
 
 
 @pytest.mark.usefixtures("run_with_tensorflow")
+@run_in_graph_mode
 def test_meta_hashing():
     """Make sure we can hash meta graphs."""
     N = 100
@@ -172,6 +198,7 @@ def test_meta_hashing():
 
 
 @pytest.mark.usefixtures("run_with_tensorflow")
+@run_in_graph_mode
 def test_meta_types():
     """Make sure our custom types/classes check out."""
 
@@ -181,6 +208,7 @@ def test_meta_types():
 
 
 @pytest.mark.usefixtures("run_with_tensorflow")
+@run_in_graph_mode
 def test_meta_compare():
     """Make objects compare correctly."""
 
@@ -199,6 +227,7 @@ def test_meta_compare():
 
 
 @pytest.mark.usefixtures("run_with_tensorflow")
+@run_in_graph_mode
 def test_meta_multi_output():
     """Make sure we can handle TF `Operation`s that output more than on tensor."""
     d, U, V = mt.linalg.svd(var())
@@ -213,6 +242,7 @@ def test_meta_multi_output():
 
 
 @pytest.mark.usefixtures("run_with_tensorflow")
+@run_in_graph_mode
 def test_meta_reify():
     a_mt = mt(tf.compat.v1.placeholder('float64', name='a', shape=[1, 2]))
     b_mt = mt(tf.compat.v1.placeholder('float64', name='b', shape=[]))
@@ -236,6 +266,7 @@ def test_meta_reify():
 
 
 @pytest.mark.usefixtures("run_with_tensorflow")
+@run_in_graph_mode
 def test_meta_distributions():
     N = 100
     sigma_tf = tfd.Gamma(np.asarray(1.), np.asarray(1.)).sample()
@@ -270,6 +301,7 @@ def test_meta_distributions():
 
 
 @pytest.mark.usefixtures("run_with_tensorflow")
+@run_in_graph_mode
 def test_inputs_remapping():
     t1 = [[1, 2, 3], [4, 5, 6]]
     t2 = [[7, 8, 9], [10, 11, 12]]

--- a/tests/tensorflow/test_printing.py
+++ b/tests/tensorflow/test_printing.py
@@ -2,15 +2,37 @@ import io
 import textwrap
 
 import pytest
-
+import numpy as np
 import tensorflow as tf
 
 from contextlib import redirect_stdout
 
+from tensorflow.python.eager.context import graph_mode
+
 from symbolic_pymc.tensorflow.printing import tf_dprint
+
+from tests.tensorflow import run_in_graph_mode
 
 
 @pytest.mark.usefixtures("run_with_tensorflow")
+def test_eager_mode():
+
+    assert tf.executing_eagerly()
+
+    N = 100
+    X = np.vstack([np.random.randn(N), np.ones(N)]).T
+    X_tf = tf.convert_to_tensor(X)
+
+    with pytest.raises(ValueError):
+        tf_dprint(X_tf)
+
+    with graph_mode():
+        X_tf = tf.convert_to_tensor(X)
+        tf_dprint(X_tf)
+
+
+@pytest.mark.usefixtures("run_with_tensorflow")
+@run_in_graph_mode
 def test_ascii_printing():
     """Make sure we can ascii/text print a TF graph."""
 
@@ -44,6 +66,7 @@ def test_ascii_printing():
 
 
 @pytest.mark.usefixtures("run_with_tensorflow")
+@run_in_graph_mode
 def test_unknown_shape():
     """Make sure we can ascii/text print a TF graph with unknown shapes."""
 

--- a/tests/tensorflow/test_unify.py
+++ b/tests/tensorflow/test_unify.py
@@ -7,10 +7,12 @@ from unification import unify, reify, var
 from symbolic_pymc.tensorflow.meta import (TFlowOpName, mt, TFlowMetaTensorShape)
 from symbolic_pymc.etuple import (ExpressionTuple, etuple, etuplize)
 
+from tests.tensorflow import run_in_graph_mode
 from tests.tensorflow.utils import assert_ops_equal
 
 
 @pytest.mark.usefixtures("run_with_tensorflow")
+@run_in_graph_mode
 def test_etuple_term():
     a = tf.compat.v1.placeholder(tf.float64, name='a')
     b = tf.compat.v1.placeholder(tf.float64, name='b')
@@ -50,6 +52,7 @@ def test_etuple_term():
 
 
 @pytest.mark.usefixtures("run_with_tensorflow")
+@run_in_graph_mode
 def test_basic_unify_reify():
     # Test reification with manually constructed replacements
     a = tf.compat.v1.placeholder(tf.float64, name='a')
@@ -80,6 +83,7 @@ def test_basic_unify_reify():
 
 
 @pytest.mark.usefixtures("run_with_tensorflow")
+@run_in_graph_mode
 def test_sexp_unify_reify():
     """Make sure we can unify and reify etuples/S-exps."""
     # Unify `A . (x + y)`, for `x`, `y` logic variables


### PR DESCRIPTION
Importing `symbolic_pymc` will now no longer disable TensorFlow's eager-mode.  

**Users will still need to provide `symbolic_pymc` TF objects with graphs**, which&mdash;for example&mdash;can be done using the context manager `tensorflow.python.eager.context.graph_mode`.