### PR TITLE
Remove meta accessor wrapper functions and add an additional OpDef name lookup

### DIFF
--- a/tests/tensorflow/test_meta.py
+++ b/tests/tensorflow/test_meta.py
@@ -49,6 +49,8 @@ def test_meta_helper():
     assert mt.add.obj.name == 'Add'
     assert isinstance(mt.matmul, TFlowMetaOpDef)
     assert mt.matmul.obj.name == 'MatMul'
+    assert isinstance(mt.RandomStandardNormal, TFlowMetaOpDef)
+    assert mt.RandomStandardNormal.obj.name == 'RandomStandardNormal'
 
 
 @pytest.mark.usefixtures("run_with_tensorflow")


### PR DESCRIPTION
The TensorFlow meta accessor, `symbolic_pymc.tensorflow.meta.mt`, will now look for `OpDef`s directly by name and no longer return confusing and marginally useful wrapper functions.

This fixes cases like `mt.RandomStandardNormal`.

Ideally, `mt` would return entirely re-worked backend helper functions: i.e. ones that have all uses of `tf.*` replaced by their corresponding `mt.*` functions.  This would be a pretty involved AST-based endeavour, but it might still be possible to produce a lot more meta object coverage for user-level backend (i.e. `tf`) functionality without solving every edge case.

Closes #51.