### PR TITLE
Turn list arguments into tuples

### DIFF
--- a/symbolic_pymc/tensorflow/meta.py
+++ b/symbolic_pymc/tensorflow/meta.py
@@ -480,7 +480,16 @@ class TFlowMetaOp(TFlowMetaSymbol):
         if isvar(inputs):
             self.inputs = inputs
         else:
-            self.inputs = tuple(metatize(i) for i in inputs)
+
+            def _convert_inputs(i):
+                i = metatize(i)
+                # Inputs are supposed to be immutable, so we're able to convert
+                # lists to tuples.
+                if isinstance(i, list):
+                    i = tuple(i)
+                return i
+
+            self.inputs = tuple(_convert_inputs(i) for i in inputs)
 
         super().__init__(obj=obj)
 

--- a/tests/tensorflow/test_meta.py
+++ b/tests/tensorflow/test_meta.py
@@ -311,7 +311,9 @@ def test_inputs_remapping():
 
     z_mt = mt(z)
 
-    assert isinstance(z_mt.inputs[0], list)
+    # Even though we gave it unhashable arguments, the operator should've
+    # converted them
+    assert isinstance(z_mt.inputs[0], tuple)
     assert z_mt.inputs[0][0].obj == z.op.inputs[0]
     assert z_mt.inputs[0][1].obj == z.op.inputs[1]
     assert z_mt.inputs[1].obj == z.op.inputs[2]


### PR DESCRIPTION
Everything in a meta graph is (generally) supposed to be immutable (and, thus, hashable), and, since some TF operators take list-based inputs, we need to convert them to tuples.

This shows up when "metatizing" `tf.concat`, and it raises errors when one attempts to debug print these meta graphs.