### PR TITLE
Efficient miniKanren stream functions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,3 +14,5 @@ filterwarnings =
 [coverage:report]
 exclude_lines =
     pragma: no cover
+
+    raise NotImplementedError

--- a/symbolic_pymc/constraints.py
+++ b/symbolic_pymc/constraints.py
@@ -1,0 +1,163 @@
+from abc import ABC, abstractmethod
+from types import MappingProxyType
+from collections import OrderedDict, defaultdict
+
+from unification import unify, reify, Var
+from unification.core import _unify, _reify
+
+
+class KanrenConstraintStore(ABC):
+    """A class that enforces constraints between logic variables in a miniKanren state."""
+
+    @abstractmethod
+    def pre_check(self, state, key=None, value=None):
+        """Check a key-value pair before they're added to a KanrenState."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def post_check(self, new_state, key=None, value=None, old_state=None):
+        """Check a key-value pair after they're added to a KanrenState."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def update(self, *args, **kwargs):
+        """Add a new constraint."""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def constraints_str(self, var):
+        """Print the constraints on a logic variable."""
+        raise NotImplementedError()
+
+
+class KanrenState(dict):
+    """A miniKanren state that holds unifications of logic variables and upholds constraints on logic variables."""
+
+    __slots__ = ("constraints",)
+
+    def __init__(self, *s, constraints=None):
+        super().__init__(*s)
+        self.constraints = OrderedDict(constraints or [])
+
+    def pre_checks(self, key, value):
+        return all(cstore.pre_check(self, key, value) for cstore in self.constraints.values())
+
+    def post_checks(self, new_state, key, value):
+        return all(
+            cstore.post_check(new_state, key, value, old_state=self)
+            for cstore in self.constraints.values()
+        )
+
+    def add_constraint(self, constraint):
+        assert isinstance(constraint, KanrenConstraintStore)
+        self.constraints[type(constraint)] = constraint
+
+    def __eq__(self, other):
+        if isinstance(other, KanrenState):
+            return super().__eq__(other)
+
+        # When comparing with a plain dict, disregard the constraints.
+        if isinstance(other, dict):
+            return super().__eq__(other)
+        return False
+
+    def __repr__(self):
+        return f"KanrenState({super().__repr__()}, {self.constraints})"
+
+
+class Disequality(KanrenConstraintStore):
+    """A disequality constraint (i.e. two things do not unify)."""
+
+    def __init__(self, mappings=None):
+        # Unallowed mappings
+        self.mappings = mappings or defaultdict(set)
+
+    def post_check(self, new_state, key=None, value=None, old_state=None):
+        return not any(
+            any(new_state == unify(lvar, val, new_state) for val in vals)
+            for lvar, vals in self.mappings.items()
+        )
+
+    def pre_check(self, state, key=None, value=None):
+        return True
+
+    def update(self, key, value):
+        self.mappings[key].add(value)
+
+    def constraints_str(self, var):
+        if var in self.mappings:
+            return f"=/= {self.mappings[var]}"
+        else:
+            return ""
+
+    def __repr__(self):
+        return ",".join([f"{k} =/= {v}" for k, v in self.mappings.items()])
+
+
+def unify_KanrenState(u, v, S):
+    if S.pre_checks(u, v):
+        s = unify(u, v, MappingProxyType(S))
+        if s is not False and S.post_checks(s, u, v):
+            return KanrenState(s, constraints=S.constraints)
+
+    return False
+
+
+unify.add((object, object, KanrenState), unify_KanrenState)
+unify.add(
+    (object, object, MappingProxyType),
+    lambda u, v, d: unify.dispatch(type(u), type(v), dict)(u, v, d),
+)
+_unify.add(
+    (object, object, MappingProxyType),
+    lambda u, v, d: _unify.dispatch(type(u), type(v), dict)(u, v, d),
+)
+
+
+class ConstrainedVar(Var):
+    """A logic variable that tracks its own constraints.
+
+    Currently, this is only for display/reification purposes.
+
+    """
+
+    def __new__(cls, var, S):
+        obj = super().__new__(cls, var.token)
+        obj.S = S
+        obj.var = var
+        return obj
+
+    def __repr__(self):
+        u_constraints = ",".join([c.constraints_str(self.var) for c in self.S.constraints.values()])
+        return f"{self.var}: {{{u_constraints}}}"
+
+
+def reify_KanrenState(u, S):
+    u_res = reify(u, MappingProxyType(S))
+    if isinstance(u_res, Var):
+        return ConstrainedVar(u_res, S)
+    else:
+        return u_res
+
+
+_reify.add((tuple(p[0] for p in _reify.ordering if p[1] == dict), KanrenState), reify_KanrenState)
+_reify.add((object, MappingProxyType), lambda u, s: _reify.dispatch(type(u), dict)(u, s))
+
+
+def neq(u, v):
+    """Construct a disequality goal."""
+
+    def neq_goal(S):
+        if not isinstance(S, KanrenState):
+            S = KanrenState(S)
+
+        diseq_constraint = S.constraints.setdefault(Disequality, Disequality())
+
+        diseq_constraint.update(u, v)
+
+        if diseq_constraint.post_check(S):
+            return iter([S])
+        else:
+            return iter([])
+
+    return neq_goal

--- a/symbolic_pymc/relations/__init__.py
+++ b/symbolic_pymc/relations/__init__.py
@@ -1,7 +1,12 @@
-from unification import isvar
+from itertools import tee, chain
+from functools import reduce
+
+from toolz import interleave
+
+from unification import isvar, reify
 
 from kanren import eq
-from kanren.core import lallgreedy
+from kanren.core import goaleval
 from kanren.facts import Relation
 from kanren.goals import goalify
 from kanren.term import term, operator, arguments
@@ -20,13 +25,85 @@ conjugate = Relation("conjugate")
 concat = goalify(lambda *args: "".join(args))
 
 
+def ldisj_seq(goals):
+    """Produce a goal that returns the appended state stream from all successful goal arguments.
+
+    In other words, it behaves like logical disjunction/OR for goals.
+    """
+
+    def ldisj_seq_goal(S):
+        nonlocal goals
+
+        goals, _goals = tee(goals)
+
+        yield from interleave(goaleval(g)(S) for g in _goals)
+
+    return ldisj_seq_goal
+
+
+def lconj_seq(goals):
+    """Produce a goal that returns the appended state stream in which all goals are necessarily successful.
+
+    In other words, it behaves like logical conjunction/AND for goals.
+    """
+
+    def lconj_seq_goal(S):
+        nonlocal goals
+
+        goals, _goals = tee(goals)
+
+        g0 = next(iter(_goals), None)
+
+        if g0 is None:
+            return
+
+        z0 = goaleval(g0)(S)
+
+        yield from reduce(lambda z, g: chain.from_iterable(map(goaleval(g), z)), _goals, z0)
+
+    return lconj_seq_goal
+
+
+def ldisj(*goals):
+    return ldisj_seq(goals)
+
+
+def lconj(*goals):
+    return lconj_seq(goals)
+
+
+def conde(*goals):
+    return ldisj_seq(lconj_seq(g) for g in goals)
+
+
+lall = lconj
+lany = ldisj
+
+
 def buildo(op, args, obj):
-    if not isvar(obj):
-        if not isvar(args):
-            args = etuplize(args, shallow=True)
-        oop, oargs = operator(obj), arguments(obj)
-        return lallgreedy(eq(op, oop), eq(args, oargs))
-    elif isvar(args) or isvar(op):
-        return conso(op, args, obj)
-    else:
-        return eq(obj, term(op, args))
+    """Construct a goal that relates an object and its rand + rators decomposition.
+
+    This version uses etuples.
+
+    """
+
+    def buildo_goal(S):
+        nonlocal op, args, obj
+
+        op, args, obj = reify((op, args, obj), S)
+
+        if not isvar(obj):
+
+            if not isvar(args):
+                args = etuplize(args, shallow=True)
+
+            oop, oargs = operator(obj), arguments(obj)
+
+            yield from lall(eq(op, oop), eq(args, oargs))(S)
+
+        elif isvar(args) or isvar(op):
+            yield from conso(op, args, obj)(S)
+        else:
+            yield from eq(obj, term(op, args))(S)
+
+    return buildo_goal

--- a/symbolic_pymc/relations/graph.py
+++ b/symbolic_pymc/relations/graph.py
@@ -7,8 +7,9 @@ from kanren.core import goaleval
 
 from kanren import eq
 from cons.core import ConsPair, ConsNull
-from kanren.core import conde, lall
 from kanren.goals import conso, fail
+
+from . import conde, lall
 
 from ..etuple import etuplize, ExpressionTuple
 
@@ -217,7 +218,7 @@ def graph_applyo(
         def preprocess_graph(x):
             return x
 
-    def _gapplyo(s):
+    def graph_applyo_goal(s):
 
         nonlocal in_graph, out_graph
 
@@ -256,4 +257,4 @@ def graph_applyo(
         g = goaleval(g)
         yield from g(s)
 
-    return _gapplyo
+    return graph_applyo_goal

--- a/symbolic_pymc/tensorflow/unify.py
+++ b/symbolic_pymc/tensorflow/unify.py
@@ -8,19 +8,20 @@ from .meta import TFlowMetaSymbol
 from ..meta import metatize
 from ..unify import unify_MetaSymbol
 from ..etuple import etuplize
+from ..constraints import KanrenState
 
 tf_class_abstractions = tuple(c.base for c in TFlowMetaSymbol.base_subclasses())
 
 _unify.add(
-    (TFlowMetaSymbol, tf_class_abstractions, dict),
+    (TFlowMetaSymbol, tf_class_abstractions, (KanrenState, dict)),
     lambda u, v, s: unify_MetaSymbol(u, metatize(v), s),
 )
 _unify.add(
-    (tf_class_abstractions, TFlowMetaSymbol, dict),
+    (tf_class_abstractions, TFlowMetaSymbol, (KanrenState, dict)),
     lambda u, v, s: unify_MetaSymbol(metatize(u), v, s),
 )
 _unify.add(
-    (tf_class_abstractions, tf_class_abstractions, dict),
+    (tf_class_abstractions, tf_class_abstractions, (KanrenState, dict)),
     lambda u, v, s: unify_MetaSymbol(metatize(u), metatize(v), s),
 )
 
@@ -30,7 +31,7 @@ def _reify_TFlowClasses(o, s):
     return reify(meta_obj, s)
 
 
-_reify.add((tf_class_abstractions, dict), _reify_TFlowClasses)
+_reify.add((tf_class_abstractions, (KanrenState, dict)), _reify_TFlowClasses)
 
 operator.add((tf.Tensor,), lambda x: operator(metatize(x)))
 

--- a/symbolic_pymc/theano/unify.py
+++ b/symbolic_pymc/theano/unify.py
@@ -4,24 +4,25 @@ from kanren.term import term, operator, arguments
 
 from unification.core import _reify, _unify, reify
 
+from .meta import TheanoMetaSymbol
 from ..meta import metatize
 from ..unify import unify_MetaSymbol
 from ..etuple import ExpressionTuple, etuplize
-from .meta import TheanoMetaSymbol
+from ..constraints import KanrenState
 
 
 tt_class_abstractions = tuple(c.base for c in TheanoMetaSymbol.base_subclasses())
 
 _unify.add(
-    (TheanoMetaSymbol, tt_class_abstractions, dict),
+    (TheanoMetaSymbol, tt_class_abstractions, (KanrenState, dict)),
     lambda u, v, s: unify_MetaSymbol(u, metatize(v), s),
 )
 _unify.add(
-    (tt_class_abstractions, TheanoMetaSymbol, dict),
+    (tt_class_abstractions, TheanoMetaSymbol, (KanrenState, dict)),
     lambda u, v, s: unify_MetaSymbol(metatize(u), v, s),
 )
 _unify.add(
-    (tt_class_abstractions, tt_class_abstractions, dict),
+    (tt_class_abstractions, tt_class_abstractions, (KanrenState, dict)),
     lambda u, v, s: unify_MetaSymbol(metatize(u), metatize(v), s),
 )
 
@@ -31,7 +32,7 @@ def _reify_TheanoClasses(o, s):
     return reify(meta_obj, s)
 
 
-_reify.add((tt_class_abstractions, dict), _reify_TheanoClasses)
+_reify.add((tt_class_abstractions, (KanrenState, dict)), _reify_TheanoClasses)
 
 operator.add((tt.Variable,), lambda x: operator(metatize(x)))
 

--- a/tests/test_goals.py
+++ b/tests/test_goals.py
@@ -1,0 +1,110 @@
+from unification import var
+
+from kanren import eq  # , run, lall
+# from kanren.core import goaleval
+
+from symbolic_pymc.relations import lconj, lconj_seq, ldisj, ldisj_seq, conde
+
+
+def test_lconj_basics():
+
+    res = list(lconj(eq(1, var('a')), eq(2, var('b')))({}))
+    assert res == [{var('a'): 1, var('b'): 2}]
+
+    res = list(lconj(eq(1, var('a')))({}))
+    assert res == [{var('a'): 1}]
+
+    res = list(lconj_seq([])({}))
+    assert res == []
+
+    res = list(lconj(eq(1, var('a')), eq(2, var('a')))({}))
+    assert res == []
+
+    res = list(lconj(eq(1, 2))({}))
+    assert res == []
+
+    res = list(lconj(eq(1, 1))({}))
+    assert res == [{}]
+
+
+def test_ldisj_basics():
+
+    res = list(ldisj(eq(1, var('a')))({}))
+    assert res == [{var('a'): 1}]
+
+    res = list(ldisj(eq(1, 2))({}))
+    assert res == []
+
+    res = list(ldisj(eq(1, 1))({}))
+    assert res == [{}]
+
+    res = list(ldisj(eq(1, var('a')), eq(1, var('a')))({}))
+    assert res == [{var('a'): 1}, {var('a'): 1}]
+
+    res = list(ldisj(eq(1, var('a')), eq(2, var('a')))({}))
+    assert res == [{var('a'): 1}, {var('a'): 2}]
+
+    res = list(ldisj_seq([])({}))
+    assert res == []
+
+
+def test_conde_basics():
+
+    res = list(conde([eq(1, var('a')), eq(2, var('b'))],
+                     [eq(1, var('b')), eq(2, var('a'))])({}))
+    assert res == [{var('a'): 1, var('b'): 2},
+                   {var('b'): 1, var('a'): 2}]
+
+    res = list(conde([eq(1, var('a')), eq(2, 1)],
+                     [eq(1, var('b')), eq(2, var('a'))])({}))
+    assert res == [{var('b'): 1, var('a'): 2}]
+
+    res = list(conde([eq(1, var('a')),
+                      conde([eq(11, var('aa'))],
+                            [eq(12, var('ab'))])],
+                     [eq(1, var('b')),
+                      conde([eq(111, var('ba')),
+                             eq(112, var('bb'))],
+                            [eq(121, var('bc'))])])({}))
+    assert res == [{var('a'): 1, var('aa'): 11},
+                   {var('b'): 1, var('ba'): 111, var('bb'): 112},
+                   {var('a'): 1, var('ab'): 12},
+                   {var('b'): 1, var('bc'): 121}]
+
+    res = list(conde([eq(1, 2)], [eq(1, 1)])({}))
+    assert res == [{}]
+
+    assert list(lconj(eq(1, 1))({})) == [{}]
+
+    res = list(lconj(conde([eq(1, 2)], [eq(1, 1)]))({}))
+    assert res == [{}]
+
+    res = list(lconj(conde([eq(1, 2)], [eq(1, 1)]),
+                     conde([eq(1, 2)], [eq(1, 1)]))({}))
+    assert res == [{}]
+
+# def test_short_circuit_lconj():
+#
+#     def one_bad_goal(goal_nums, good_goals=10, _eq=eq):
+#         for i in goal_nums:
+#             if i == good_goals:
+#                 def _g(S, i=i):
+#                     print('{} bad'.format(i))
+#                     yield from _eq(1, 2)(S)
+#
+#             else:
+#                 def _g(S, i=i):
+#                     print('{} good'.format(i))
+#                     yield from _eq(1, 1)(S)
+#
+#             yield _g
+#
+#     goal_nums = iter(range(20))
+#     run(0, var('q'), lall(*one_bad_goal(goal_nums)))
+#
+#     # `kanren`'s `lall` will necessarily exhaust the generator.
+#     next(goal_nums, None)
+#
+#     goal_nums = iter(range(20))
+#     run(0, var('q'), lconj(one_bad_goal(goal_nums)))
+#     next(goal_nums, None)

--- a/tests/test_goals.py
+++ b/tests/test_goals.py
@@ -1,7 +1,6 @@
 from unification import var
 
-from kanren import eq  # , run, lall
-# from kanren.core import goaleval
+from kanren import eq
 
 from symbolic_pymc.relations import lconj, lconj_seq, ldisj, ldisj_seq, conde
 
@@ -82,29 +81,3 @@ def test_conde_basics():
     res = list(lconj(conde([eq(1, 2)], [eq(1, 1)]),
                      conde([eq(1, 2)], [eq(1, 1)]))({}))
     assert res == [{}]
-
-# def test_short_circuit_lconj():
-#
-#     def one_bad_goal(goal_nums, good_goals=10, _eq=eq):
-#         for i in goal_nums:
-#             if i == good_goals:
-#                 def _g(S, i=i):
-#                     print('{} bad'.format(i))
-#                     yield from _eq(1, 2)(S)
-#
-#             else:
-#                 def _g(S, i=i):
-#                     print('{} good'.format(i))
-#                     yield from _eq(1, 1)(S)
-#
-#             yield _g
-#
-#     goal_nums = iter(range(20))
-#     run(0, var('q'), lall(*one_bad_goal(goal_nums)))
-#
-#     # `kanren`'s `lall` will necessarily exhaust the generator.
-#     next(goal_nums, None)
-#
-#     goal_nums = iter(range(20))
-#     run(0, var('q'), lconj(one_bad_goal(goal_nums)))
-#     next(goal_nums, None)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -269,8 +269,10 @@ def test_graph_applyo_reverse():
     assert test_res == (
         # Expansion of the term's root
         etuple(add, 5, 5),
+        # Expansion in the term's arguments
+        etuple(mul, etuple(log, etuple(exp, 2)), etuple(log, etuple(exp, 5))),
         # Two step expansion at the root
-        etuple(log, etuple(exp, etuple(add, 5, 5))),
+        # etuple(log, etuple(exp, etuple(add, 5, 5))),
         # Expansion into a sub-term
         # etuple(mul, 2, etuple(log, etuple(exp, 5)))
     )

--- a/tests/test_kanren.py
+++ b/tests/test_kanren.py
@@ -1,0 +1,101 @@
+from itertools import permutations
+
+from unification import var, unify
+from unification.core import _reify
+
+from kanren import run, eq
+
+from symbolic_pymc.relations import lconj
+from symbolic_pymc.constraints import KanrenState, Disequality, neq, ConstrainedVar
+
+
+def test_kanrenstate():
+
+    ks = KanrenState()
+
+    assert repr(ks) == 'KanrenState({}, OrderedDict())'
+
+    assert ks == {}
+    assert {} == ks
+    assert not ks == {var('a'): 1}
+    assert not ks == KanrenState({var('a'): 1})
+
+    assert unify(1, 1, ks) is not None
+    assert unify(1, 2, ks) is False
+
+    assert unify(var('b'), var('a'), ks)
+    assert unify(var('a'), var('b'), ks)
+    assert unify(var('a'), var('b'), ks)
+
+    # Now, try that with a constraint (that's never used).
+    ks.add_constraint(Disequality({var('a'): {1}}))
+
+    assert ks == {}
+    assert {} == ks
+    assert not ks == {var('a'): 1}
+    assert not ks == KanrenState({var('a'): 1})
+
+    assert unify(1, 1, ks) is not None
+    assert unify(1, 2, ks) is False
+
+    assert unify(var('b'), var('a'), ks)
+    assert unify(var('a'), var('b'), ks)
+    assert unify(var('a'), var('b'), ks)
+
+
+def test_reify():
+    ks = KanrenState()
+    assert repr(ConstrainedVar(var('a'), ks)) == '~a: {}'
+
+    de = Disequality({var('a'): {1, 2}})
+    ks.add_constraint(de)
+
+    assert repr(de) == '~a =/= {1, 2}'
+    assert de.constraints_str(var()) == ""
+    assert repr(ConstrainedVar(var('a'), ks)) == '~a: {=/= {1, 2}}'
+
+    # TODO: Make this work with `reify` when `var('a')` isn't in `ks`.
+    assert isinstance(_reify(var('a'), ks), ConstrainedVar)
+    assert repr(_reify(var('a'), ks)) == '~a: {=/= {1, 2}}'
+
+
+def test_disequality():
+
+    ks = KanrenState()
+    de = Disequality({var('a'): {1}})
+    ks.add_constraint(de)
+
+    assert unify(var('a'), 1, ks) is False
+
+    ks = unify(var('a'), var('b'), ks)
+    assert unify(var('b'), 1, ks) is False
+
+    res = list(lconj(neq(var('a'), 1))({}))
+    assert len(res) == 1
+    assert isinstance(res[0], KanrenState)
+    assert res[0].constraints[Disequality].mappings[var('a')] == {1}
+
+    res = list(lconj(neq(var('a'), 1), eq(var('a'), 2))({}))
+    assert len(res) == 1
+    assert isinstance(res[0], KanrenState)
+    assert res[0].constraints[Disequality].mappings[var('a')] == {1}
+    assert res[0][var('a')] == 2
+
+    res = list(lconj(eq(var('a'), 1), neq(var('a'), 1))({}))
+    assert res == []
+
+    goal_sets = [([neq(var('a'), 1)], 1),
+                 ([neq(var('a'), 1), eq(var('a'), 1)], 0),
+                 ([neq(var('a'), 1), eq(var('b'), 1), eq(var('a'), var('b'))], 0)]
+
+    for goal, results in goal_sets:
+        # The order of goals should not matter, so try them all
+        for goal_ord in permutations(goal):
+
+            res = list(lconj(*goal_ord)({}))
+            assert len(res) == results
+
+            res = list(lconj(*goal_ord)(KanrenState()))
+            assert len(res) == results
+
+            assert len(run(0, var('q'), *goal_ord)) == results

--- a/tests/test_kanren.py
+++ b/tests/test_kanren.py
@@ -75,6 +75,11 @@ def test_disequality():
     assert isinstance(res[0], KanrenState)
     assert res[0].constraints[Disequality].mappings[var('a')] == {1}
 
+    res = list(lconj(neq(var('a'), 1), neq(var('a'), 2), neq(var('a'), 1))({}))
+    assert len(res) == 1
+    assert isinstance(res[0], KanrenState)
+    assert res[0].constraints[Disequality].mappings[var('a')] == {1, 2}
+
     res = list(lconj(neq(var('a'), 1), eq(var('a'), 2))({}))
     assert len(res) == 1
     assert isinstance(res[0], KanrenState)


### PR DESCRIPTION
Addressing some of the issues in #58.  Should probably move this to the `kanren` project, though.

FYI: We can't really replace the existing `kanren` `lall` and `lany` functions with these new ones until we've implemented a new form of constraints, since a few `symbolic-pymc` goals (indirectly) use `kanren`'s exception-based system (i.e. `EarlyGoalError`s + tuple expressions).