### PR TITLE
Introduce a somewhat usable "metatize" for TF helper functions

### DIFF
--- a/tests/tensorflow/test_meta.py
+++ b/tests/tensorflow/test_meta.py
@@ -401,3 +401,25 @@ def test_metatize():
 
     with pytest.raises(ValueError):
         mt(CustomClass())
+
+
+@pytest.mark.usefixtures("run_with_tensorflow")
+@run_in_graph_mode
+def test_metatize_function():
+
+    # A_tf = tf.convert_to_tensor(np.c_[[1, 2], [3, 4]])
+    A_tf = tf.compat.v1.placeholder(tf.float64, name='A',
+                                    shape=tf.TensorShape([None, None]))
+
+    A_shape_tf = tf.shape(A_tf)
+    A_rows_tf = A_shape_tf[0]
+    I_A_tf = tf.eye(A_rows_tf)
+
+    # A_mt = mt(A_tf)
+    # A_shape_mt = mt.shape(A_mt)
+    # A_rows_tf = mt.StridedSlice(A_shape_mt, 0, 1, 1, shrink_axis_mask=1)
+    A_rows_mt = mt(A_rows_tf)
+
+    eye_mt = mt.metatize_tf_function(tf.eye, A_rows_mt)
+
+    assert mt(I_A_tf) == eye_mt


### PR DESCRIPTION
This addresses #56 in another way; namely, it uses an intermediate/temporary TF graph that mirrors a given meta graph with the meta tensor terms replaced by `Placeholder`s.  The temporary TF graph is given to the TF function we want to metatize, the result is turned into a meta graph (i.e. "metatized") and the `Placeholder` stand-ins are replaced by the original meta tensors.

The reason this seems like a worthwhile approach: `Placeholders` have some flexibility for unknown shape and dtype information, so, when meta tensors use logic variables for those values, we have a workable mapping between meta tensors and valid TF tensors.

Naturally, this approach has its limits, and the reason is that some TF helper functions simply do not accept unknown shape and dtype input (i.e. "variant" dtype).  However, the better we are about inferring/specifying dtype and shape information (when it's possible to do so) for meta objects, the better this approach will work.  

For instance, the meta versions of indexing operations (e.g. `tf.raw_ops.StridedSlice`) cannot derive/infer the dtypes for their output automatically, yet the task is completely do-able.