### PR TITLE
Update pinned TF and TFP to latest versions

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -264,7 +264,7 @@ ignore-mixin-members=yes
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
+ignored-modules=tensorflow.core.framework,tensorflow.python.framework
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set). This supports can work

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 scipy>=1.2.0
 Theano>=1.0.4
-tf-nightly-2.0-preview==2.0.0.dev20190606
-tfp-nightly==0.8.0.dev20190705
+gast==0.2.2
+tf-nightly-2.0-preview==2.0.0.dev20190908
+tensorflow-estimator-2.0-preview==1.14.0.dev2019090801
+tfp-nightly==0.9.0.dev20190908
 pymc3>=3.6
 pymc4 @ git+https://github.com/pymc-devs/pymc4.git@master#egg=pymc4-0.0.1
 multipledispatch>=0.6.0

--- a/tests/tensorflow/test_unify.py
+++ b/tests/tensorflow/test_unify.py
@@ -70,8 +70,8 @@ def test_basic_unify_reify():
     test_base_res = test_reify_res.reify()
     assert isinstance(test_base_res, tf.Tensor)
 
-    expected_res = (tf.constant(1, dtype=tf.float64) +
-                    tf.constant(2, dtype=tf.float64) * a)
+    expected_res = tf.add(tf.constant(1, dtype=tf.float64),
+                          tf.constant(2, dtype=tf.float64) * a)
     assert_ops_equal(test_base_res, expected_res)
 
     # Simply make sure that unification succeeds
@@ -94,7 +94,7 @@ def test_sexp_unify_reify():
     y = tf.compat.v1.placeholder(tf.float64, name='y',
                                  shape=tf.TensorShape([None, 1]))
 
-    z = tf.matmul(A, x + y)
+    z = tf.matmul(A, tf.add(x, y))
 
     z_sexp = etuplize(z)
 

--- a/tests/tensorflow/utils.py
+++ b/tests/tensorflow/utils.py
@@ -2,6 +2,7 @@ from collections.abc import Mapping
 
 import tensorflow as tf
 
+
 def assert_ops_equal(a, b, compare_fn=lambda a, b: a.op.type == b.op.type):
     if hasattr(a, 'op') or hasattr(b, 'op'):
         assert hasattr(a, 'op') and hasattr(b, 'op')


### PR DESCRIPTION
These updates required changes to the TF tensor and operation name handling, since TF seems to have changed the `OpDef`s behind `__add__` addition.  Likewise, these name changes smooth out some pre-existing inconsistencies between method and function-based operations in TF (e.g. `__mul__` would use the lower-case "mul", which goes against their capitalized naming convention used in most other cases).

Comparisons using `TFlowOpName` are now case insensitive (for better or worse). Also, the `Operation` name is now used as the name value returned by `TFlowMetaTensor.inputs`, along with other related fixes that allow `TFlowMetaTensor.op` to be a logic variable.