### PR TITLE
Fix unify when walked values are Numpy arrays

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 pydocstyle>=3.0.0
-pytest>=4.2.0
+pytest>=5.0.0
 pytest-cov>=2.6.1
 pytest-html>=1.20.0
 pylint>=2.3.1

--- a/tests/tensorflow/test_meta.py
+++ b/tests/tensorflow/test_meta.py
@@ -167,6 +167,7 @@ def test_meta_create():
     with pytest.raises(TypeError):
         TFlowMetaTensor('float64', 'Add', name='q__')
 
+
 @pytest.mark.usefixtures("run_with_tensorflow")
 @run_in_graph_mode
 def test_meta_Op():
@@ -194,7 +195,6 @@ def test_meta_Op():
         assert MetaSymbol.is_meta(test_op.reify())
         assert isinstance(test_op.outputs, tuple)
         assert MetaSymbol.is_meta(test_op.outputs[0])
-
 
 
 @pytest.mark.usefixtures("run_with_tensorflow")
@@ -381,7 +381,7 @@ def test_opdef_sig():
 
     custom_opdef_tf.attr.extend([attr1_tf, attr2_tf])
 
-    opdef_sig = MetaOpDefLibrary.make_opdef_sig(custom_opdef_tf)
+    opdef_sig, opdef_func = MetaOpDefLibrary.make_opdef_sig(custom_opdef_tf)
 
     import inspect
     # These are standard inputs
@@ -431,3 +431,13 @@ def test_metatize():
 
     with pytest.raises(ValueError):
         mt(CustomClass())
+
+
+@pytest.mark.usefixtures("run_with_tensorflow")
+@run_in_graph_mode
+def test_opdef_func():
+    sum_mt = mt.Sum([[1, 2]], [1])
+    sum_tf = sum_mt.reify()
+
+    with tf.compat.v1.Session() as sess:
+        assert sum_tf.eval() == np.r_[3]

--- a/tests/test_unify.py
+++ b/tests/test_unify.py
@@ -36,3 +36,15 @@ def test_numpy():
     s = unify([1, var('a')], np_array)
 
     assert s is False
+
+    s = unify(var('a'), 2, {var('a'): np_array})
+
+    assert s is False
+
+    s = unify(var('a'), var('b'), {var('a'): np_array})
+
+    assert s[var('a')] is np_array
+    assert s[var('b')] is np_array
+
+    s = unify(np_array, np_array)
+    assert s == {}


### PR DESCRIPTION
Expressions like `unify(var('a'), var('b'), {var('a'): np.r_[1, 2]})` fail because `unify` uses the base implementation and `walk`s the `dict` and results in an exception caused by `np.r_[1, 2] == var('b')`.

Also, `TFlowMetaOpDef.__call__` fails when an `OpDef`'s inputs have names that don't match the corresponding `tf.raw_ops.*` function (e.g. `tf.raw_ops.Sum` has arguments named `input` and `axis`, while the `OpDef` for `Sum` uses `input` and `reduction_indices`).