### PR TITLE
Make better use of slots and cache hash values

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pytest-cov>=2.6.1
 pytest-html>=1.20.0
 pylint>=2.3.1
 black>=19.3b0
+ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,10 @@
 scipy>=1.2.0
 Theano>=1.0.4
-gast==0.2.2
+pymc4 @ git+https://github.com/pymc-devs/pymc4.git@master#egg=pymc4-0.0.1
+tfp-nightly==0.9.0.dev20190908
 tf-nightly-2.0-preview==2.0.0.dev20190908
 tensorflow-estimator-2.0-preview==1.14.0.dev2019090801
-tfp-nightly==0.9.0.dev20190908
 pymc3>=3.6
-pymc4 @ git+https://github.com/pymc-devs/pymc4.git@master#egg=pymc4-0.0.1
 multipledispatch>=0.6.0
 unification>=0.2.2
 kanren @ git+https://github.com/pymc-devs/kanren.git@symbolic-pymc#egg=kanren-0.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pymc4 @ git+https://github.com/pymc-devs/pymc4.git@master#egg=pymc4-0.0.1
 multipledispatch>=0.6.0
 unification>=0.2.2
 kanren @ git+https://github.com/pymc-devs/kanren.git@symbolic-pymc#egg=kanren-0.2.3
+cons>=0.1.3
 toolz>=0.9.0
 sympy>=1.3
 cachetools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 scipy>=1.2.0
 Theano>=1.0.4
 pymc4 @ git+https://github.com/pymc-devs/pymc4.git@master#egg=pymc4-0.0.1
-tfp-nightly==0.9.0.dev20190908
-tf-nightly-2.0-preview==2.0.0.dev20190908
-tensorflow-estimator-2.0-preview==1.14.0.dev2019090801
+tfp-nightly==0.9.0.dev20191003
+tf-nightly-2.0-preview==2.0.0.dev20191002
+tensorflow-estimator-2.0-preview>=1.14.0.dev2019090801
 pymc3>=3.6
 multipledispatch>=0.6.0
 unification>=0.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ unification>=0.2.2
 kanren @ git+https://github.com/pymc-devs/kanren.git@symbolic-pymc#egg=kanren-0.2.3
 toolz>=0.9.0
 sympy>=1.3
+cachetools

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,6 @@ convention = numpy
 
 [tool:pytest]
 python_functions=test_*
+filterwarnings =
+    ignore:the imp module is deprecated:DeprecationWarning:
+    ignore:Using a non-tuple sequence:FutureWarning:theano\.tensor

--- a/symbolic_pymc/meta.py
+++ b/symbolic_pymc/meta.py
@@ -259,19 +259,23 @@ class MetaSymbol(metaclass=MetaSymbolType):
         return hash((self.base, self.rands()))
 
     def __str__(self):
-        obj = getattr(self, "obj", None)
-        if obj is None:
-            res = self.__repr__()
-        else:
-            res = f"{self.__class__.__name__}({str(obj)})"
-        return res
+        return self.__repr__(show_obj=False, _repr=str)
 
-    def __repr__(self):
+    def __repr__(self, show_obj=True, _repr=meta_repr.repr):
+        rands = self.rands()
+
+        if rands:
+            args = _repr(self.rands())[1:-1]
+        else:
+            args = ""
+
         obj = getattr(self, "obj", None)
-        args = meta_repr.repr(self.rands()).strip("()")
-        if args:
-            args += ", "
-        args += f"obj={meta_repr.repr(obj)}"
+
+        if (show_obj and obj is not None) or not args:
+            if args:
+                args += ", "
+            args += f"obj={_repr(obj)}"
+
         return "{}({})".format(self.__class__.__name__, args)
 
     def _repr_pretty_(self, p, cycle):
@@ -279,7 +283,7 @@ class MetaSymbol(metaclass=MetaSymbolType):
             p.text(f"{self.__class__.__name__}(...)")
         else:
             with p.group(2, f"{self.__class__.__name__}(", ")"):
-                p.breakable()
+                p.breakable(sep="")
                 idx = None
                 if hasattr(self, "__all_props__"):
                     for idx, (name, item) in enumerate(zip(self.__all_props__, self.rands())):

--- a/symbolic_pymc/relations/__init__.py
+++ b/symbolic_pymc/relations/__init__.py
@@ -22,11 +22,10 @@ concat = goalify(lambda *args: "".join(args))
 
 def buildo(op, args, obj):
     if not isvar(obj):
-        if not (isinstance(obj, ExpressionTuple) and isinstance(args, ExpressionTuple)):
-            obj = etuplize(obj, shallow=True)
+        if not isvar(args):
             args = etuplize(args, shallow=True)
         oop, oargs = operator(obj), arguments(obj)
-        return lallgreedy((eq, op, oop), (eq, args, oargs))
+        return lallgreedy(eq(op, oop), eq(args, oargs))
     elif isvar(args) or isvar(op):
         return conso(op, args, obj)
     else:

--- a/symbolic_pymc/relations/graph.py
+++ b/symbolic_pymc/relations/graph.py
@@ -124,7 +124,11 @@ def reduceo(relation, in_expr, out_expr):
 
 
 def graph_applyo(
-    relation, in_graph, out_graph, preprocess_graph=partial(etuplize, shallow=True), inside=False
+    relation,
+    in_graph,
+    out_graph,
+    preprocess_graph=partial(etuplize, shallow=True, return_bad_args=True),
+    inside=False,
 ):
     """Relate the fixed-points of two term-graphs under a given relation.
 

--- a/symbolic_pymc/relations/graph.py
+++ b/symbolic_pymc/relations/graph.py
@@ -5,7 +5,7 @@ from unification import reify
 from kanren.core import goaleval
 
 from kanren import eq
-from kanren.cons import is_cons, is_null
+from cons.core import ConsPair, ConsNull
 from kanren.core import conde, lall
 from kanren.goals import conso, fail
 
@@ -75,11 +75,11 @@ def lapply_anyo(relation, l_in, l_out, null_type=False, skip_op=True):
             l_out_, l_in_ = reify((l_out, l_in), s)
 
             out_null_type = False
-            if is_cons(l_out_) or is_null(l_out_):
+            if isinstance(l_out_, (ConsPair, ConsNull)):
                 out_null_type = type(l_out_)()
 
             in_null_type = False
-            if is_cons(l_in_) or is_null(l_in_):
+            if isinstance(l_in_, (ConsPair, ConsNull)):
                 in_null_type = type(l_in_)()
 
                 if out_null_type is not False and not type(in_null_type) == type(out_null_type):

--- a/symbolic_pymc/tensorflow/meta.py
+++ b/symbolic_pymc/tensorflow/meta.py
@@ -345,7 +345,12 @@ class TFlowMetaOpDef(MetaOp, metaclass=OpDefFactoryType):
         return f"{self.__class__.__name__}({self.obj.name})"
 
     def _repr_pretty_(self, p, cycle):
-        return p.text(f"{self.__class__.__name__}({self.obj.name})")
+        if cycle:
+            p.text(f"{self.__class__.__name__}(...)")
+        else:
+            with p.group(2, f"{self.__class__.__name__}(", ")"):
+                p.breakable(sep="")
+                p.text(self.obj.name)
 
     def __eq__(self, other):
         if self is other:

--- a/symbolic_pymc/tensorflow/unify.py
+++ b/symbolic_pymc/tensorflow/unify.py
@@ -4,10 +4,10 @@ from kanren.term import term, operator, arguments
 
 from unification.core import _reify, _unify, reify
 
+from .meta import TFlowMetaSymbol
 from ..meta import metatize
 from ..unify import unify_MetaSymbol
 from ..etuple import ExpressionTuple, etuplize
-from .meta import TFlowMetaSymbol
 
 tf_class_abstractions = tuple(c.base for c in TFlowMetaSymbol.__subclasses__())
 

--- a/symbolic_pymc/theano/meta.py
+++ b/symbolic_pymc/theano/meta.py
@@ -212,7 +212,12 @@ class TheanoMetaOp(MetaOp, TheanoMetaSymbol):
         return f"{self.__class__.__name__}({self.obj})"
 
     def _repr_pretty_(self, p, cycle):
-        return p.text(f"{self.__class__.__name__}({self.obj})")
+        if cycle:
+            p.text(f"{self.__class__.__name__}(...)")
+        else:
+            with p.group(2, f"{self.__class__.__name__}(", ")"):
+                p.breakable(sep="")
+                p.text(getattr(self.obj, "name", str(self.obj)))
 
 
 class TheanoMetaElemwise(TheanoMetaOp):

--- a/symbolic_pymc/theano/pymc3.py
+++ b/symbolic_pymc/theano/pymc3.py
@@ -90,108 +90,108 @@ def _convert_rv_to_dist(op, rv):
     return pm.Uniform, params
 
 
-@dispatch(pm.Normal, object)
-def convert_dist_to_rv(dist, rng):
+@convert_dist_to_rv.register(pm.Normal, object)
+def convert_dist_to_rv_Normal(dist, rng):
     size = dist.shape.astype(int)[NormalRV.ndim_supp :]
     res = NormalRV(dist.mu, dist.sd, size=size, rng=rng)
     return res
 
 
-@dispatch(NormalRVType, Apply)
-def _convert_rv_to_dist(op, rv):
+@_convert_rv_to_dist.register(NormalRVType, Apply)
+def _convert_rv_to_dist_Normal(op, rv):
     params = {"mu": rv.inputs[0], "sd": rv.inputs[1]}
     return pm.Normal, params
 
 
-@dispatch(pm.HalfNormal, object)
-def convert_dist_to_rv(dist, rng):
+@convert_dist_to_rv.register(pm.HalfNormal, object)
+def convert_dist_to_rv_HalfNormal(dist, rng):
     size = dist.shape.astype(int)[HalfNormalRV.ndim_supp :]
     res = HalfNormalRV(np.array(0.0, dtype=dist.dtype), dist.sd, size=size, rng=rng)
     return res
 
 
-@dispatch(HalfNormalRVType, Apply)
-def _convert_rv_to_dist(op, rv):
+@_convert_rv_to_dist.register(HalfNormalRVType, Apply)
+def _convert_rv_to_dist_HalfNormal(op, rv):
     assert not np.any(tt_get_values(rv.inputs[0]))
     params = {"sd": rv.inputs[1]}
     return pm.HalfNormal, params
 
 
-@dispatch(pm.MvNormal, object)
-def convert_dist_to_rv(dist, rng):
+@convert_dist_to_rv.register(pm.MvNormal, object)
+def convert_dist_to_rv_MvNormal(dist, rng):
     size = dist.shape.astype(int)[MvNormalRV.ndim_supp :]
     res = MvNormalRV(dist.mu, dist.cov, size=size, rng=rng)
     return res
 
 
-@dispatch(MvNormalRVType, Apply)
-def _convert_rv_to_dist(op, rv):
+@_convert_rv_to_dist.register(MvNormalRVType, Apply)
+def _convert_rv_to_dist_MvNormal(op, rv):
     params = {"mu": rv.inputs[0], "cov": rv.inputs[1]}
     return pm.MvNormal, params
 
 
-@dispatch(pm.Gamma, object)
-def convert_dist_to_rv(dist, rng):
+@convert_dist_to_rv.register(pm.Gamma, object)
+def convert_dist_to_rv_Gamma(dist, rng):
     size = dist.shape.astype(int)[GammaRV.ndim_supp :]
     res = GammaRV(dist.alpha, tt.inv(dist.beta), size=size, rng=rng)
     return res
 
 
-@dispatch(GammaRVType, Apply)
-def _convert_rv_to_dist(op, rv):
+@_convert_rv_to_dist.register(GammaRVType, Apply)
+def _convert_rv_to_dist_Gamma(op, rv):
     params = {"alpha": rv.inputs[0], "beta": rv.inputs[1]}
     return pm.Gamma, params
 
 
-@dispatch(pm.InverseGamma, object)
-def convert_dist_to_rv(dist, rng):
+@convert_dist_to_rv.register(pm.InverseGamma, object)
+def convert_dist_to_rv_InverseGamma(dist, rng):
     size = dist.shape.astype(int)[InvGammaRV.ndim_supp :]
     res = InvGammaRV(dist.alpha, scale=dist.beta, size=size, rng=rng)
     return res
 
 
-@dispatch(InvGammaRVType, Apply)
-def _convert_rv_to_dist(op, rv):
+@_convert_rv_to_dist.register(InvGammaRVType, Apply)
+def _convert_rv_to_dist_InvGamma(op, rv):
     assert not np.any(tt_get_values(rv.inputs[1]))
     params = {"alpha": rv.inputs[0], "beta": rv.inputs[2]}
     return pm.InverseGamma, params
 
 
-@dispatch(pm.Exponential, object)
-def convert_dist_to_rv(dist, rng):
+@convert_dist_to_rv.register(pm.Exponential, object)
+def convert_dist_to_rv_Exponential(dist, rng):
     size = dist.shape.astype(int)[ExponentialRV.ndim_supp :]
     res = ExponentialRV(tt.inv(dist.lam), size=size, rng=rng)
     return res
 
 
-@dispatch(ExponentialRVType, Apply)
-def _convert_rv_to_dist(op, rv):
+@_convert_rv_to_dist.register(ExponentialRVType, Apply)
+def _convert_rv_to_dist_Exponential(op, rv):
     params = {"lam": tt.inv(rv.inputs[0])}
     return pm.Exponential, params
 
 
-@dispatch(pm.Cauchy, object)
-def convert_dist_to_rv(dist, rng):
+@convert_dist_to_rv.register(pm.Cauchy, object)
+def convert_dist_to_rv_Cauchy(dist, rng):
     size = dist.shape.astype(int)[CauchyRV.ndim_supp :]
     res = CauchyRV(dist.alpha, dist.beta, size=size, rng=rng)
     return res
 
 
-@dispatch(CauchyRVType, Apply)
-def _convert_rv_to_dist(op, rv):
+@_convert_rv_to_dist.register(CauchyRVType, Apply)
+def _convert_rv_to_dist_Cauchy(op, rv):
     params = {"alpha": rv.inputs[0], "beta": rv.inputs[1]}
     return pm.Cauchy, params
 
 
-@dispatch(pm.HalfCauchy, object)
-def convert_dist_to_rv(dist, rng):
+@convert_dist_to_rv.register(pm.HalfCauchy, object)
+def convert_dist_to_rv_HalfCauchy(dist, rng):
     size = dist.shape.astype(int)[HalfCauchyRV.ndim_supp :]
     res = HalfCauchyRV(np.array(0.0, dtype=dist.dtype), dist.beta, size=size, rng=rng)
     return res
 
 
-@dispatch(HalfCauchyRVType, Apply)
-def _convert_rv_to_dist(op, rv):
+@_convert_rv_to_dist.register(HalfCauchyRVType, Apply)
+def _convert_rv_to_dist_HalfCauchy(op, rv):
     # TODO: Assert that `rv.inputs[0]` must be all zeros!
     params = {"beta": rv.inputs[1]}
     return pm.HalfCauchy, params

--- a/symbolic_pymc/unify.py
+++ b/symbolic_pymc/unify.py
@@ -73,10 +73,10 @@ unify.add((object, object, dict), unify_numpy)
 def unify_MetaSymbol(u, v, s):
     if type(u) != type(v):
         return False
-    if hasattr(u, "__slots__"):
+    if hasattr(u, "__all_props__"):
         s = unify(
-            [getattr(u, slot) for slot in u.__slots__],
-            [getattr(v, slot) for slot in v.__slots__],
+            [getattr(u, slot) for slot in u.__all_props__],
+            [getattr(v, slot) for slot in v.__all_props__],
             s,
         )
     elif u != v:

--- a/symbolic_pymc/unify.py
+++ b/symbolic_pymc/unify.py
@@ -2,6 +2,7 @@ from functools import wraps
 
 import numpy as np
 
+from cons import cdr
 from kanren.term import term, operator, arguments
 
 from unification.more import unify

--- a/tests/tensorflow/test_meta.py
+++ b/tests/tensorflow/test_meta.py
@@ -102,7 +102,7 @@ def test_meta_create():
     # Create a (constant) tensor meta object manually.
     X_raw_mt = TFlowMetaConstant(obj=X)
 
-    assert X_raw_mt.data is X
+    assert X_raw_mt._data is X
 
     # These are *not* equivalent, since they're constants without matching
     # constant values (well, our manually-created meta constant has no constant
@@ -146,8 +146,8 @@ def test_meta_create():
     # tf.add(1, 2).op.node_def
     # tf.add(tf.convert_to_tensor(1), tf.convert_to_tensor(2)).op.node_def
 
-    add_mt.op.node_def.input = [None, None]
-    add_mt_2.op.node_def.input = [None, None]
+    # add_mt.op.node_def.input = [None, None]
+    # add_mt_2.op.node_def.input = [None, None]
     assert add_mt == add_mt_2
 
     a_mt = mt(tf.compat.v1.placeholder('float64', name='a', shape=[1, 2]))
@@ -202,18 +202,18 @@ def test_meta_lvars():
     """Make sure we can use lvars as values."""
 
     nd_mt = TFlowMetaNodeDef(var(), var(), var())
-    assert all(isvar(getattr(nd_mt, s)) for s in nd_mt.__slots__)
+    assert all(isvar(getattr(nd_mt, s)) for s in nd_mt.__all_props__)
 
     mo_mt = TFlowMetaOp(var(), var(), var(), var())
-    assert all(isvar(getattr(mo_mt, s)) for s in mo_mt.__slots__)
+    assert all(isvar(getattr(mo_mt, s)) for s in mo_mt.__all_props__)
 
     ts_mt = TFlowMetaTensorShape(var())
-    assert all(isvar(getattr(ts_mt, s)) for s in ts_mt.__slots__)
+    assert all(isvar(getattr(ts_mt, s)) for s in ts_mt.__all_props__)
 
     assert isvar(ts_mt.as_list())
 
     tn_mt = TFlowMetaTensor(var(), var(), var(), var(), var())
-    assert all(isvar(getattr(tn_mt, s)) for s in tn_mt.__slots__)
+    assert all(isvar(getattr(tn_mt, s)) for s in tn_mt.__all_props__)
 
 
 @pytest.mark.usefixtures("run_with_tensorflow")
@@ -292,7 +292,7 @@ def test_meta_reify():
     assert add_tf.shape.as_list() == [1, 2]
 
     # Remove cached base object and force manual reification.
-    add_mt.obj = None
+    add_mt._obj = None
     add_tf = add_mt.reify()
 
     assert isinstance(add_tf, tf.Tensor)
@@ -320,9 +320,9 @@ def test_meta_distributions():
     # Now, let's see if we can reconstruct it entirely from the
     # meta objects.
     def _remove_obj(meta_obj):
-        if (hasattr(meta_obj, 'obj') and
+        if (hasattr(meta_obj, '_obj') and
                 not isinstance(meta_obj, TFlowMetaOpDef)):
-            meta_obj.obj = None
+            meta_obj._obj = None
 
         if hasattr(meta_obj, 'ancestors'):
             for a in meta_obj.ancestors or []:

--- a/tests/tensorflow/test_unify.py
+++ b/tests/tensorflow/test_unify.py
@@ -77,7 +77,7 @@ def test_basic_unify_reify():
     # Simply make sure that unification succeeds
     meta_expected_res = mt(expected_res)
     s_test = unify(test_expr, meta_expected_res, {})
-    assert len(s_test) == 5
+    assert len(s_test) == 3
 
     assert reify(test_expr, s_test) == meta_expected_res
 

--- a/tests/tensorflow/test_unify.py
+++ b/tests/tensorflow/test_unify.py
@@ -18,7 +18,7 @@ def test_etuple_term():
     b = tf.compat.v1.placeholder(tf.float64, name='b')
 
     a_mt = mt(a)
-    a_mt.obj = None
+    a_mt._obj = None
     a_reified = a_mt.reify()
     assert isinstance(a_reified, tf.Tensor)
     assert a_reified.shape.dims is None
@@ -57,7 +57,7 @@ def test_basic_unify_reify():
     # Test reification with manually constructed replacements
     a = tf.compat.v1.placeholder(tf.float64, name='a')
     x_l = var('x_l')
-    a_reif = reify(x_l, {x_l: a})
+    a_reif = reify(x_l, {x_l: mt(a)})
     assert a_reif.obj is not None
     # Confirm that identity is preserved (i.e. that the underlying object
     # was properly tracked and not unnecessarily reconstructed)

--- a/tests/test_etuple.py
+++ b/tests/test_etuple.py
@@ -4,7 +4,7 @@ from operator import add
 
 from kanren.term import term, operator, arguments
 
-from symbolic_pymc.etuple import (ExpressionTuple, etuple)
+from symbolic_pymc.etuple import (ExpressionTuple, etuple, KwdPair)
 
 
 def test_etuple():
@@ -117,3 +117,25 @@ def test_etuple_kwargs():
     e8 = etuple(enumerate, etuple(list, ['a', 'b', 'c', 'd']),
                 start=etuple(add, 1, etuple(add, 1, 1)))
     assert list(e8.eval_obj) == [(3, 'a'), (4, 'b'), (5, 'c'), (6, 'd')]
+
+    # Use "eval_obj" kwarg and make sure it doesn't end up in the `_tuple` object
+    e9 = etuple(add, 1, 2, eval_obj=3)
+    assert e9._tuple == (add, 1, 2)
+    assert e9._eval_obj == 3
+
+
+def test_str():
+    et = etuple(1, etuple("a", 2), etuple(3, "b"))
+    assert repr(et) == "ExpressionTuple((1, ExpressionTuple(('a', 2)), ExpressionTuple((3, 'b'))))"
+    assert str(et) == 'e(1, e(a, 2), e(3, b))'
+
+    kw = KwdPair('a', 1)
+
+    assert repr(kw) == "KwdPair('a', 1)"
+    assert str(kw) == 'a=1'
+
+
+def test_pprint():
+    pretty_mod = pytest.importorskip("IPython.lib.pretty")
+    et = etuple(1, etuple("a", *range(20)), etuple(3, "b"), blah=etuple('c', 0))
+    assert pretty_mod.pretty(et) == "e(\n  1,\n  e('a', 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19),\n  e(3, 'b'),\n  blah=e(c, 0))"

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -116,16 +116,18 @@ def test_meta_str():
 
     some_mt = SomeMetaSymbol()
 
-    assert repr(some_mt) == 'SomeMetaSymbol(1, 2, obj=None)'
+    assert repr(some_mt) == 'SomeMetaSymbol(1, 2)'
     assert str(some_mt) == repr(some_mt)
 
     some_mt = SomeMetaSymbol(SomeType(1, 2))
 
     assert repr(some_mt) == 'SomeMetaSymbol(1, 2, obj=SomeType(1, 2))'
-    assert str(some_mt) == 'SomeMetaSymbol(SomeType<1, 2>)'
+    assert str(some_mt) == 'SomeMetaSymbol(1, 2)'
+
+    some_op_mt = SomeMetaOp()
+    assert repr(some_op_mt) == 'SomeMetaOp(obj=None)'
 
     some_op_mt = SomeMetaOp(SomeOp())
-
     assert repr(some_op_mt) == 'SomeMetaOp(obj=<SomeOp>)'
 
 
@@ -135,15 +137,15 @@ def test_meta_pretty():
 
     some_mt = SomeMetaSymbol()
 
-    assert pretty_mod.pretty(some_mt) == 'SomeMetaSymbol( field1=1, field2=2)'
+    assert pretty_mod.pretty(some_mt) == 'SomeMetaSymbol(field1=1, field2=2)'
 
     meta_repr.print_obj = True
 
-    assert pretty_mod.pretty(some_mt) == 'SomeMetaSymbol( field1=1, field2=2)'
+    assert pretty_mod.pretty(some_mt) == 'SomeMetaSymbol(field1=1, field2=2)'
 
     some_mt = SomeMetaSymbol(SomeType(1, 2))
 
-    assert pretty_mod.pretty(some_mt) == 'SomeMetaSymbol( field1=1, field2=2, obj=SomeType(1, 2))'
+    assert pretty_mod.pretty(some_mt) == 'SomeMetaSymbol(field1=1, field2=2, obj=SomeType(1, 2))'
 
     meta_repr.print_obj = False
 
@@ -151,4 +153,4 @@ def test_meta_pretty():
     some_mt.field1 = SomeMetaSymbol(SomeType(3, 4))
     some_mt.field1.field2 = SomeMetaSymbol(SomeType(5, 6))
 
-    assert pretty_mod.pretty(some_mt) == 'SomeMetaSymbol(\n  field1=SomeMetaSymbol( field1=1, field2=SomeMetaSymbol( field1=1, field2=2)),\n  field2=2)'
+    assert pretty_mod.pretty(some_mt) == 'SomeMetaSymbol(\n  field1=SomeMetaSymbol(field1=1, field2=SomeMetaSymbol(field1=1, field2=2)),\n  field2=2)'

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,10 +1,23 @@
-from symbolic_pymc.meta import MetaSymbol
+import pytest
+
+from symbolic_pymc.meta import MetaSymbol, MetaOp
+
+
+class SomeOp(object):
+    def __repr__(self):
+        return '<SomeOp>'
 
 
 class SomeType(object):
     def __init__(self, field1, field2):
         self.field1 = field1
         self.field2 = field2
+
+    def __repr__(self):
+        return f'SomeType({self.field1}, {self.field2})'
+
+    def __str__(self):
+        return f'SomeType<{self.field1}, {self.field2}>'
 
 
 class SomeMetaSymbol(MetaSymbol):
@@ -18,15 +31,26 @@ class SomeMetaSymbol(MetaSymbol):
         self._blah = 'a'
 
 
+class SomeMetaOp(MetaOp):
+    __slots__ = ()
+    base = SomeOp
+
+    def out_meta_types(self):
+        return [SomeMetaSymbol]
+
+    def __call__(self, *args, **kwargs):
+        return SomeMetaSymbol(*args, **kwargs)
+
+
 def test_meta():
     """Make sure hash caching and slot manipulation works."""
 
     some_mt = SomeMetaSymbol()
 
-    assert some_mt.__all_slots__ == ('_obj', '_hash', 'field1', 'field2', '_blah')
+    assert some_mt.__all_slots__ == ('_obj', '_hash', '_rands', 'field1', 'field2', '_blah')
     assert some_mt.__all_props__ == ('field1', 'field2')
     assert some_mt.__props__ == ('field1', 'field2')
-    assert some_mt.__volatile_slots__ == ('_obj', '_hash', '_blah')
+    assert some_mt.__volatile_slots__ == ('_obj', '_hash', '_rands', '_blah')
 
     assert some_mt.obj is None
     assert not hasattr(some_mt, '_hash')
@@ -54,6 +78,11 @@ def test_meta():
     assert some_mt._hash == some_new_hash
     assert some_new_hash != some_hash
 
+    some_op_mt = SomeMetaOp(SomeOp())
+
+    with pytest.raises(AttributeError):
+        some_op_mt.obj = SomeOp()
+
 
 def test_meta_inheritance():
     class SomeOtherType(SomeType):
@@ -72,9 +101,54 @@ def test_meta_inheritance():
         def __hash__(self):
             return hash((super().__hash__(), self.field3))
 
+    some_mt = SomeMetaSymbol()
     other_mt = SomeOtherMetaSymbol()
 
-    assert other_mt.__all_slots__ == ('_obj', '_hash', 'field1', 'field2', '_blah', 'field3', '_bloh')
+    assert some_mt != other_mt
+
+    assert other_mt.__all_slots__ == ('_obj', '_hash', '_rands', 'field1', 'field2', '_blah', 'field3', '_bloh')
     assert other_mt.__all_props__ == ('field1', 'field2', 'field3')
     assert other_mt.__props__ == ('field3',)
-    assert other_mt.__volatile_slots__ == ('_obj', '_hash', '_blah', '_bloh')
+    assert other_mt.__volatile_slots__ == ('_obj', '_hash', '_rands', '_blah', '_bloh')
+
+
+def test_meta_str():
+
+    some_mt = SomeMetaSymbol()
+
+    assert repr(some_mt) == 'SomeMetaSymbol(1, 2, obj=None)'
+    assert str(some_mt) == repr(some_mt)
+
+    some_mt = SomeMetaSymbol(SomeType(1, 2))
+
+    assert repr(some_mt) == 'SomeMetaSymbol(1, 2, obj=SomeType(1, 2))'
+    assert str(some_mt) == 'SomeMetaSymbol(SomeType<1, 2>)'
+
+    some_op_mt = SomeMetaOp(SomeOp())
+
+    assert repr(some_op_mt) == 'SomeMetaOp(obj=<SomeOp>)'
+
+
+def test_meta_pretty():
+    pretty_mod = pytest.importorskip("IPython.lib.pretty")
+    from symbolic_pymc.meta import meta_repr
+
+    some_mt = SomeMetaSymbol()
+
+    assert pretty_mod.pretty(some_mt) == 'SomeMetaSymbol( field1=1, field2=2)'
+
+    meta_repr.print_obj = True
+
+    assert pretty_mod.pretty(some_mt) == 'SomeMetaSymbol( field1=1, field2=2)'
+
+    some_mt = SomeMetaSymbol(SomeType(1, 2))
+
+    assert pretty_mod.pretty(some_mt) == 'SomeMetaSymbol( field1=1, field2=2, obj=SomeType(1, 2))'
+
+    meta_repr.print_obj = False
+
+    some_mt = SomeMetaSymbol(SomeType(1, 2))
+    some_mt.field1 = SomeMetaSymbol(SomeType(3, 4))
+    some_mt.field1.field2 = SomeMetaSymbol(SomeType(5, 6))
+
+    assert pretty_mod.pretty(some_mt) == 'SomeMetaSymbol(\n  field1=SomeMetaSymbol( field1=1, field2=SomeMetaSymbol( field1=1, field2=2)),\n  field2=2)'

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,0 +1,80 @@
+from symbolic_pymc.meta import MetaSymbol
+
+
+class SomeType(object):
+    def __init__(self, field1, field2):
+        self.field1 = field1
+        self.field2 = field2
+
+
+class SomeMetaSymbol(MetaSymbol):
+    __slots__ = ('field1', 'field2', '_blah')
+    base = SomeType
+
+    def __init__(self, obj=None):
+        super().__init__(obj)
+        self.field1 = 1
+        self.field2 = 2
+        self._blah = 'a'
+
+
+def test_meta():
+    """Make sure hash caching and slot manipulation works."""
+
+    some_mt = SomeMetaSymbol()
+
+    assert some_mt.__all_slots__ == ('_obj', '_hash', 'field1', 'field2', '_blah')
+    assert some_mt.__all_props__ == ('field1', 'field2')
+    assert some_mt.__props__ == ('field1', 'field2')
+    assert some_mt.__volatile_slots__ == ('_obj', '_hash', '_blah')
+
+    assert some_mt.obj is None
+    assert not hasattr(some_mt, '_hash')
+
+    some_hash = hash(some_mt)
+
+    assert some_mt._hash == some_hash
+
+    assert some_mt.field1 == 1
+    assert some_mt.field2 == 2
+
+    # This assignment shouldn't change the cached values
+    some_mt._blah = 'b'
+
+    assert some_mt._hash == some_hash
+
+    # This should
+    some_mt.field1 = 10
+
+    assert some_mt._hash is None
+    assert some_mt._blah is None
+
+    some_new_hash = hash(some_mt)
+
+    assert some_mt._hash == some_new_hash
+    assert some_new_hash != some_hash
+
+
+def test_meta_inheritance():
+    class SomeOtherType(SomeType):
+        def __init__(self, field1, field2, field3):
+            super().__init__(field1, field2)
+            self.field3 = field3
+
+    class SomeOtherMetaSymbol(SomeMetaSymbol):
+        __slots__ = ('field3', '_bloh')
+        base = SomeOtherType
+
+        def __init__(self, obj=None):
+            super().__init__(obj)
+            self.field3 = 3
+
+        def __hash__(self):
+            return hash((super().__hash__(), self.field3))
+
+    other_mt = SomeOtherMetaSymbol()
+
+    assert other_mt.__all_slots__ == ('_obj', '_hash', 'field1', 'field2', '_blah', 'field3', '_bloh')
+    assert other_mt.__all_props__ == ('field1', 'field2', 'field3')
+    assert other_mt.__props__ == ('field3',)
+    assert other_mt.__volatile_slots__ == ('_obj', '_hash', '_blah', '_bloh')

--- a/tests/test_unify.py
+++ b/tests/test_unify.py
@@ -3,7 +3,32 @@ import numpy as np
 # Needed to set up unify dispatch functions
 import symbolic_pymc.unify
 
-from unification import unify, var
+from unification import unify, var, reify
+
+from cons import cons
+
+from symbolic_pymc.etuple import etuple, ExpressionTuple
+
+
+def test_etuple():
+    et = etuple(var('a'),)
+    res = reify(et, {var('a'): 1})
+    assert isinstance(res, ExpressionTuple)
+
+    et = etuple(var('a'),)
+    res = unify(et, (1,))
+    assert res == {var('a'): 1}
+
+    from operator import add
+
+    et = etuple(add, 1, 2)
+    assert et.eval_obj == 3
+
+    res = unify(et, cons(var('a'), var('b')))
+    assert res == {var('a'): add,
+                   var('b'): et[1:]}
+
+    assert ((res[var('a')],) + res[var('b')])._eval_obj == 3
 
 
 def test_numpy():

--- a/tests/theano/test_meta.py
+++ b/tests/theano/test_meta.py
@@ -6,8 +6,12 @@ import theano.tensor as tt
 import pytest
 
 from unification import var, isvar, variables
-from symbolic_pymc.meta import MetaSymbol
+from symbolic_pymc.meta import MetaSymbol, MetaOp
 from symbolic_pymc.theano.meta import (metatize,
+                                       TheanoMetaOp,
+                                       TheanoMetaApply,
+                                       TheanoMetaVariable,
+                                       TheanoMetaTensorConstant,
                                        TheanoMetaTensorVariable,
                                        TheanoMetaTensorType, mt)
 from symbolic_pymc.theano.utils import graph_equal
@@ -48,11 +52,15 @@ def test_metatize():
 
     class TestOp(tt.gof.Op):
         pass
-    test_out = metatize(TestOp)
 
-    assert isinstance(test_out, MetaSymbol)
-    assert test_out.obj == TestOp
-    assert test_out.base == TestOp
+    test_out = metatize(TestOp)
+    assert issubclass(test_out, MetaOp)
+
+    test_op_tt = TestOp()
+    test_obj = test_out(obj=test_op_tt)
+    assert isinstance(test_obj, MetaSymbol)
+    assert test_obj.obj == test_op_tt
+    assert test_obj.base == TestOp
 
 
 @pytest.mark.usefixtures("run_with_theano")
@@ -87,3 +95,98 @@ def test_meta_classes():
     # TODO: Do we really want meta variables to be equal to their
     # reified base objects?
     # assert meta_vars == [tt.as_tensor_variable(x) for x in test_vals]
+
+    name_mt = var()
+    add_tt = tt.add(0, 1)
+    add_mt = mt.add(0, 1, name=name_mt)
+
+    assert add_mt.name is name_mt
+    assert add_tt.type == add_mt.type.reify()
+    assert mt(add_tt.owner) == add_mt.owner
+    # assert isvar(add_mt._obj)
+
+    # Let's confirm that we can dynamically create a new meta `Op` type
+    test_mat = np.c_[[2, 3], [4, 5]]
+
+    svd_tt = tt.nlinalg.SVD()(test_mat)
+    # First, can we create one from a new base `Op` instance?
+    svd_op_mt = mt(tt.nlinalg.SVD())
+    svd_mt = svd_op_mt(test_mat)
+
+    assert svd_mt[0].owner.nin == 1
+    assert svd_mt[0].owner.nout == 3
+
+    svd_outputs = svd_mt[0].owner.outputs
+    assert svd_outputs[0] == svd_mt[0]
+    assert svd_outputs[1] == svd_mt[1]
+    assert svd_outputs[2] == svd_mt[2]
+
+    assert mt(svd_tt) == svd_mt
+
+    # Next, can we create one from a base `Op` type/class?
+    svd_op_type_mt = mt.nlinalg.SVD
+    assert isinstance(svd_op_type_mt, type)
+    assert issubclass(svd_op_type_mt, TheanoMetaOp)
+
+    # svd_op_inst_mt = svd_op_type_mt(tt.nlinalg.SVD())
+    # svd_op_inst_mt(test_mat) == svd_mt
+
+    # Apply node with logic variable as outputs
+    svd_apply_mt = TheanoMetaApply(svd_op_mt, [test_mat], outputs=var('out'))
+    assert isinstance(svd_apply_mt.inputs, tuple)
+    assert isinstance(svd_apply_mt.inputs[0], MetaSymbol)
+    assert isvar(svd_apply_mt.outputs)
+    assert svd_apply_mt.nin == 1
+    assert svd_apply_mt.nout is None
+
+    # Apply node with logic variable as inputs
+    svd_apply_mt = TheanoMetaApply(svd_op_mt, var('in'), outputs=var('out'))
+    assert svd_apply_mt.nin is None
+
+    # A meta variable with None index
+    var_mt = TheanoMetaVariable(svd_mt[0].type, svd_mt[0].owner, None, None)
+    assert var_mt.index is None
+    reified_var_mt = var_mt.reify()
+
+    assert isinstance(reified_var_mt, TheanoMetaTensorVariable)
+    assert reified_var_mt.index == 0
+    assert var_mt.index == 0
+    assert reified_var_mt == svd_mt[0]
+
+    # A meta variable with logic variable index
+    var_mt = TheanoMetaVariable(svd_mt[0].type, svd_mt[0].owner, var('index'), None)
+    assert isvar(var_mt.index)
+    reified_var_mt = var_mt.reify()
+    assert isvar(var_mt.index)
+    assert reified_var_mt.index == 0
+
+    const_mt = mt(1)
+    assert isinstance(const_mt, TheanoMetaTensorConstant)
+    assert const_mt != mt(2)
+
+
+@pytest.mark.usefixtures("run_with_theano")
+def test_meta_str():
+    assert str(mt.add) == 'TheanoMetaElemwise(Elemwise{add,no_inplace})'
+
+
+@pytest.mark.usefixtures("run_with_theano")
+def test_meta_pretty():
+    pretty_mod = pytest.importorskip("IPython.lib.pretty")
+    assert pretty_mod.pretty(mt.add) == 'TheanoMetaElemwise(Elemwise{add,no_inplace})'
+
+
+@pytest.mark.usefixtures("run_with_theano")
+def test_meta_helpers():
+    zeros_mt = mt.zeros(2)
+    assert np.array_equal(zeros_mt.reify().eval(), np.r_[0., 0.])
+
+    zeros_mt = mt.zeros(2, dtype=int)
+    assert np.array_equal(zeros_mt.reify().eval(), np.r_[0, 0])
+
+    mat_mt = mt(np.eye(2))
+    diag_mt = mt.diag(mat_mt)
+    assert np.array_equal(diag_mt.reify().eval(), np.r_[1., 1.])
+
+    diag_mt = mt.diag(mt(np.r_[1, 2, 3]))
+    assert np.array_equal(diag_mt.reify().eval(), np.diag(np.r_[1, 2, 3]))


### PR DESCRIPTION
Meta objects now use `__slots__` all throughout&mdash;effectively preventing `__dict__` entries from appearing&mdash;and cache their `__hash__` values in a "volatile" `__slots__` entry (named `_hash`) that is cleared based on an object state determined by any non-prefixed `__slots__` entries.  

The `__slots__` values that contribute to the statefulness of cached values are the `__slots__` entries *not prefixed* by an underscore; the ones with underscore prefixes are not part of the "state" and can be/are used to hold cache values.  Underscore prefixed "volatile" `__slots__` entries are cleared when the non-underscored entries are updated (via `__setattr__`).  See `MetaSymbolType.__new__` for details.

These changes appear to have sped up meta object operations quite a bit, but there's probably still more caching to consider.