### PR TITLE
Factor out fixed-point logic from graph relation

### DIFF
--- a/symbolic_pymc/relations/theano/__init__.py
+++ b/symbolic_pymc/relations/theano/__init__.py
@@ -69,9 +69,7 @@ def non_obs_graph_applyo(relation, a, b):
         # Deconstruct the observed random variable
         (buildo, rv_op_lv, rv_args_lv, obs_rv_lv),
         # Apply relation to the RV's inputs
-        lapply_anyo(
-            lambda x, y: tt_graph_applyo(relation, x, y), rv_args_lv, new_rv_args_lv, skip_op=False
-        ),
+        lapply_anyo(partial(tt_graph_applyo, relation), rv_args_lv, new_rv_args_lv, skip_op=False),
         # Reconstruct the random variable
         (buildo, rv_op_lv, new_rv_args_lv, new_obs_rv_lv),
         # Reconstruct the observation

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,4 +1,5 @@
 from operator import add, mul
+from functools import partial
 from math import log, exp
 
 import pytest
@@ -44,7 +45,7 @@ ExpressionTuple.__lt__ = lambda self, other: self < (other,) if isinstance(other
 ExpressionTuple.__gt__ = lambda self, other: self > (other,) if isinstance(other, int) else tuple(self) > tuple(other)
 
 
-def reduces(in_expr, out_expr):
+def math_reduceo(in_expr, out_expr):
     """Create a relation for a couple math-based identities."""
     x_lv = var()
     x_lv.token = f'x{x_lv.token}'
@@ -58,9 +59,33 @@ def reduces(in_expr, out_expr):
                   [(isinstanceo, [out_expr, (float, int, ExpressionTuple)], True)]))
 
 
-def math_reduceo(a, b):
+def full_math_reduceo(a, b):
     """Produce all results for repeated applications of the math-based relation."""
-    return (reduceo, reduces, a, b)
+    return (reduceo, math_reduceo, a, b)
+
+
+def fixedp_graph_applyo(r, x, y):
+    return reduceo(partial(graph_applyo, r, preprocess_graph=None), x, y)
+
+
+def test_reduceo():
+    q_lv = var()
+
+    # Reduce/forward
+    res = run(0, q_lv, full_math_reduceo(
+        etuple(log, etuple(exp, etuple(log, 1))), q_lv))
+    assert len(res) == 1
+    assert res[0] == etuple(log, 1)
+
+    res = run(0, q_lv, full_math_reduceo(
+        etuple(log, etuple(exp, etuple(log, etuple(exp, 1)))), q_lv))
+    assert res[0] == 1
+    assert res[1] == etuple(log, etuple(exp, 1))
+
+    # Expand/backward
+    res = run(2, q_lv, full_math_reduceo(q_lv, 1))
+    assert res[0] == etuple(log, etuple(exp, 1))
+    assert res[1] == etuple(log, etuple(exp, etuple(log, etuple(exp, 1))))
 
 
 def test_lapply_anyo_types():
@@ -90,6 +115,28 @@ def test_lapply_anyo_types():
     assert all(r[0] == add for r in res)
 
 
+def test_lapply_misc():
+    q_lv = var('q')
+
+    assert len(run(0, q_lv, lapply_anyo(eq, [1, 2, 3], [1, 2, 3]))) == 1
+
+    assert len(run(0, q_lv, lapply_anyo(eq, [1, 2, 3], [1, 3, 3]))) == 0
+
+    assert len(run(4, q_lv, lapply_anyo(math_reduceo, [etuple(mul, 2, var('x'))], q_lv))) == 0
+
+    test_res = run(4, q_lv, lapply_anyo(math_reduceo, [etuple(add, 2, 2), 1], q_lv))
+    assert test_res == ([etuple(mul, 2, 2), 1],)
+
+    test_res = run(4, q_lv, lapply_anyo(math_reduceo, [1, etuple(add, 2, 2)], q_lv))
+    assert test_res == ([1, etuple(mul, 2, 2)],)
+
+    test_res = run(4, q_lv, lapply_anyo(math_reduceo, q_lv, var('z')))
+    assert all(isinstance(r, list) for r in test_res)
+
+    test_res = run(4, q_lv, lapply_anyo(math_reduceo, q_lv, var('z'), tuple()))
+    assert all(isinstance(r, tuple) for r in test_res)
+
+
 @pytest.mark.parametrize(
     'test_input, test_output',
     [([], ()),
@@ -110,7 +157,7 @@ def test_lapply_anyo(test_input, test_output):
     """Test `lapply_anyo` with fully ground terms (i.e. no logic variables)."""
     q_lv = var()
     test_res = run(0, q_lv,
-                   (lapply_anyo, math_reduceo, test_input, q_lv))
+                   (lapply_anyo, full_math_reduceo, test_input, q_lv))
 
     assert len(test_res) == len(test_output)
 
@@ -133,17 +180,28 @@ def test_lapply_anyo_reverse():
     # Unbounded reverse
     q_lv = var()
     rev_input = [etuple(mul, 2, 1)]
-    test_res = run(4, q_lv, (lapply_anyo, reduces, q_lv, rev_input))
+    test_res = run(4, q_lv, (lapply_anyo, math_reduceo, q_lv, rev_input))
     assert test_res == ([etuple(add, 1, 1)],
                         [etuple(log, etuple(exp, etuple(mul, 2, 1)))])
 
     # Guided reverse
     test_res = run(4, q_lv,
-                   (lapply_anyo, reduces,
+                   (lapply_anyo, math_reduceo,
                     [etuple(add, q_lv, 1)],
                     [etuple(mul, 2, 1)]))
 
     assert test_res == (1,)
+
+
+def test_graph_applyo_misc():
+    q_lv = var('q')
+    expr = etuple(add, etuple(mul, 2, 1), etuple(add, 1, 1))
+    assert len(run(0, q_lv, graph_applyo(eq, expr, expr, preprocess_graph=None))) == 1
+
+    expr2 = etuple(add, etuple(mul, 2, 1), etuple(add, 2, 1))
+    assert len(run(0, q_lv, graph_applyo(eq, expr, expr2, preprocess_graph=None))) == 0
+
+    assert len(run(0, q_lv, graph_applyo(eq, etuple(), etuple(), preprocess_graph=None))) == 1
 
 
 @pytest.mark.parametrize(
@@ -164,8 +222,7 @@ def test_graph_applyo(test_input, test_output):
 
     q_lv = var()
     test_res = run(len(test_output), q_lv,
-                   graph_applyo(math_reduceo, test_input, q_lv,
-                                preprocess_graph=None))
+                   fixedp_graph_applyo(full_math_reduceo, test_input, q_lv))
 
     assert len(test_res) == len(test_output)
 
@@ -184,25 +241,25 @@ def test_graph_applyo_reverse():
     """Test `graph_applyo` in "reverse" (i.e. specify the reduced form and generate the un-reduced form)."""
     q_lv = var('q')
 
-    test_res = run(2, q_lv, graph_applyo(reduces, q_lv, 5))
+    test_res = run(2, q_lv, fixedp_graph_applyo(math_reduceo, q_lv, 5))
     assert test_res == (etuple(log, etuple(exp, 5)),
                         etuple(log, etuple(exp, etuple(log, etuple(exp, 5)))))
     assert all(e.eval_obj == 5.0 for e in test_res)
 
     # Make sure we get some variety in the results
-    test_res = run(3, q_lv, graph_applyo(reduces, q_lv, etuple(mul, 2, 5)))
+    test_res = run(2, q_lv, fixedp_graph_applyo(math_reduceo, q_lv, etuple(mul, 2, 5)))
     assert test_res == (
         # Expansion of the term's root
         etuple(add, 5, 5),
         # Two step expansion at the root
         etuple(log, etuple(exp, etuple(add, 5, 5))),
         # Expansion into a sub-term
-        etuple(mul, 2, etuple(log, etuple(exp, 5)))
+        # etuple(mul, 2, etuple(log, etuple(exp, 5)))
     )
     assert all(e.eval_obj == 10.0 for e in test_res)
 
     r_lv = var('r')
-    test_res = run(4, [q_lv, r_lv], graph_applyo(reduces, q_lv, r_lv))
+    test_res = run(4, [q_lv, r_lv], fixedp_graph_applyo(math_reduceo, q_lv, r_lv))
     expect_res = ([etuple(add, 1, 1), etuple(mul, 2, 1)],
                   [etuple(log, etuple(exp, etuple(add, 1, 1))), etuple(mul, 2, 1)],
                   [etuple(), etuple()],
@@ -210,20 +267,3 @@ def test_graph_applyo_reverse():
                    etuple(mul, 2, etuple(mul, 2, 1))])
     assert list(unify(a1, a2) and unify(b1, b2)
                 for [a1, b1], [a2, b2] in zip(test_res, expect_res))
-
-
-def test_lapply_scratch():
-    q_lv = var('q')
-    assert len(run(4, q_lv, lapply_anyo(reduces, [etuple(mul, 2, var('x'))], q_lv))) == 0
-
-    test_res = run(4, q_lv, lapply_anyo(reduces, [etuple(add, 2, 2), 1], q_lv))
-    assert test_res == ([etuple(mul, 2, 2), 1],)
-
-    test_res = run(4, q_lv, lapply_anyo(reduces, [1, etuple(add, 2, 2)], q_lv))
-    assert test_res == ([1, etuple(mul, 2, 2)],)
-
-    test_res = run(4, q_lv, lapply_anyo(reduces, q_lv, var('z')))
-    assert all(isinstance(r, list) for r in test_res)
-
-    test_res = run(4, q_lv, lapply_anyo(reduces, q_lv, var('z'), tuple()))
-    assert all(isinstance(r, tuple) for r in test_res)

--- a/tests/theano/test_relations.py
+++ b/tests/theano/test_relations.py
@@ -4,6 +4,7 @@ import numpy as np
 import theano
 import theano.tensor as tt
 
+from functools import partial
 from unification import var
 
 from kanren import run
@@ -11,8 +12,13 @@ from kanren import run
 from symbolic_pymc.theano.meta import mt
 from symbolic_pymc.theano.random_variables import (observed, NormalRV,
                                                    HalfCauchyRV)
-from symbolic_pymc.relations.theano import tt_graph_applyo, non_obs_graph_applyo
+from symbolic_pymc.relations.graph import reduceo
+from symbolic_pymc.relations.theano import non_obs_graph_applyo
 from symbolic_pymc.relations.theano.distributions import scale_loc_transform
+
+
+def non_obs_fixedp_graph_applyo(r, x, y):
+    return reduceo(partial(non_obs_graph_applyo, r), x, y)
 
 
 @pytest.mark.usefixtures("run_with_theano")
@@ -36,7 +42,7 @@ def test_pymc_normals():
 
     graph_mt = mt(radon_like_rv)
     expr_graph, = run(1, var('q'),
-                      non_obs_graph_applyo(scale_loc_transform, graph_mt, var('q')))
+                      non_obs_fixedp_graph_applyo(scale_loc_transform, graph_mt, var('q')))
 
     radon_like_rv_opt = expr_graph.reify()
 


### PR DESCRIPTION
Now, we have a `graph_applyo` that can be used to perform a single pass over a graph (i.e. with no recursion) and a `reduceo` that performs only a fixed-point recursion of a relation.  The two can be combined to get the same results as before (see the test changes).

Also, `graph_applyo` checks fully reifiable arguments for valid sub-graphs and avoids unnecessarily adding a goal to the stream when there aren't any.