### PR TITLE
Rename and lapply_anyo and make it return max goal conjunctions first

### DIFF
--- a/symbolic_pymc/relations/theano/__init__.py
+++ b/symbolic_pymc/relations/theano/__init__.py
@@ -6,7 +6,7 @@ from kanren import eq
 from kanren.core import lall
 
 from .linalg import buildo
-from ..graph import graph_applyo, lapply_anyo
+from ..graph import graph_applyo, seq_apply_anyo
 from ...etuple import etuplize, etuple
 from ...theano.meta import mt
 
@@ -69,7 +69,9 @@ def non_obs_graph_applyo(relation, a, b):
         # Deconstruct the observed random variable
         (buildo, rv_op_lv, rv_args_lv, obs_rv_lv),
         # Apply relation to the RV's inputs
-        lapply_anyo(partial(tt_graph_applyo, relation), rv_args_lv, new_rv_args_lv, skip_op=False),
+        seq_apply_anyo(
+            partial(tt_graph_applyo, relation), rv_args_lv, new_rv_args_lv, skip_op=False
+        ),
         # Reconstruct the random variable
         (buildo, rv_op_lv, new_rv_args_lv, new_obs_rv_lv),
         # Reconstruct the observation


### PR DESCRIPTION
The relation/goal `lapply_anyo` has been renamed to `seq_apply_anyo`.  It has also been made to return the state with the maximum number of simultaneously successful goals&mdash;for the given relation applied across both sequences&mdash;first.

This change is best explained by a simple example:

```python
from pprint import pprint
from unification import var
from kanren import run, eq, conde

from symbolic_pymc.relations.graph import seq_apply_anyo


def one_to_threeo(x, y):
    """Substitute 1 with 3."""
    return conde([eq(x, 1), eq(y, 3)])

q_lv = var('q')
res = run(0, q_lv, seq_apply_anyo(one_to_threeo,
                                  [1, 2, 4, 1, 4, 1, 1],
                                  q_lv))
```
The first result should be the list with *all* substitutions applied:
```python
>>> pprint(res)
([3, 2, 4, 3, 4, 3, 3],
 [1, 2, 4, 3, 4, 3, 3],
 [3, 2, 4, 1, 4, 3, 3],
 [1, 2, 4, 1, 4, 3, 3],
 [3, 2, 4, 3, 4, 1, 3],
 [1, 2, 4, 3, 4, 1, 3],
 [3, 2, 4, 1, 4, 1, 3],
 [1, 2, 4, 1, 4, 1, 3],
 [3, 2, 4, 3, 4, 3, 1],
 [1, 2, 4, 3, 4, 3, 1],
 [3, 2, 4, 1, 4, 3, 1],
 [1, 2, 4, 1, 4, 3, 1],
 [3, 2, 4, 3, 4, 1, 1],
 [1, 2, 4, 3, 4, 1, 1],
 [3, 2, 4, 1, 4, 1, 1])
```