### PR TITLE
Fix etuplization of strings

### DIFF
--- a/symbolic_pymc/etuple.py
+++ b/symbolic_pymc/etuple.py
@@ -5,6 +5,8 @@ import toolz
 
 from collections import Sequence
 
+from cons.core import ConsPair
+
 from multipledispatch import dispatch
 
 from kanren.term import operator, arguments
@@ -242,7 +244,7 @@ def etuplize(x, shallow=False, return_bad_args=False):
         op = None
         args = x
 
-    if not isinstance(args, Sequence) or isinstance(args, str):
+    if not isinstance(args, ConsPair):
         if return_bad_args:
             return x
         else:

--- a/tests/tensorflow/test_unify.py
+++ b/tests/tensorflow/test_unify.py
@@ -4,7 +4,7 @@ import tensorflow as tf
 
 from unification import unify, reify, var
 
-from symbolic_pymc.tensorflow.meta import (TFlowOpName, mt, TFlowMetaTensorShape)
+from symbolic_pymc.tensorflow.meta import (TFlowOpName, mt, TFlowMetaTensorShape, TFlowOpName)
 from symbolic_pymc.etuple import (ExpressionTuple, etuple, etuplize)
 
 from tests.tensorflow import run_in_graph_mode
@@ -14,6 +14,11 @@ from tests.tensorflow.utils import assert_ops_equal
 @pytest.mark.usefixtures("run_with_tensorflow")
 @run_in_graph_mode
 def test_etuple_term():
+
+    str_type = TFlowOpName("blah")
+    assert etuplize(str_type, return_bad_args=True) == str_type
+    assert etuplize("blah", return_bad_args=True) == "blah"
+
     a = tf.compat.v1.placeholder(tf.float64, name='a')
     b = tf.compat.v1.placeholder(tf.float64, name='b')
 


### PR DESCRIPTION
Our custom `UserString` class wasn't working correctly with `etuplize`:
```python
>>> etuplize(TFlowOpName("blah"))
e('b', 'l', 'a', 'h')

```
`etuplize` should not treat `str`s and `UserString`s as regular sequences.  This PR fixes that.