### PR TITLE
Add branch diff coverage check and ignore utility functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help venv conda docker docstyle format style black test lint check
+.PHONY: help venv conda docker docstyle format style black test lint check coverage
 .DEFAULT_GOAL = help
 
 PYTHON = python
@@ -58,8 +58,11 @@ black:  # Format code in-place using black.
 	black symbolic_pymc/
 
 test:  # Test code using pytest.
-	pytest -v tests/ --cov=symbolic_pymc/ --html=testing-report.html --self-contained-html
+	pytest -v tests/ --cov=symbolic_pymc/ --cov-report=xml --html=testing-report.html --self-contained-html
+
+coverage: test
+	diff-cover coverage.xml --compare-branch=master --fail-under=100
 
 lint: docstyle format style  # Lint code using pydocstyle, black and pylint.
 
-check: lint test  # Both lint and test code. Runs `make lint` followed by `make test`.
+check: lint test coverage  # Both lint and test code. Runs `make lint` followed by `make test`.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,5 @@ pytest-cov>=2.6.1
 pytest-html>=1.20.0
 pylint>=2.3.1
 black>=19.3b0
+diff-cover
 ipython

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,7 @@ python_functions=test_*
 filterwarnings =
     ignore:the imp module is deprecated:DeprecationWarning:
     ignore:Using a non-tuple sequence:FutureWarning:theano\.tensor
+
+[coverage:report]
+exclude_lines =
+    pragma: no cover

--- a/symbolic_pymc/unify.py
+++ b/symbolic_pymc/unify.py
@@ -20,7 +20,7 @@ class UnificationFailure(Exception):
     pass
 
 
-def debug_unify(enable=True):
+def debug_unify(enable=True):  # pragma: no cover
     """Wrap unify functions so that they raise a `UnificationFailure` exception when unification fails."""
     if enable:
 

--- a/symbolic_pymc/utils.py
+++ b/symbolic_pymc/utils.py
@@ -10,7 +10,7 @@ def _check_eq(a, b):
         return a == b
 
 
-def meta_parts_unequal(x, y, pdb=False):
+def meta_parts_unequal(x, y, pdb=False):  # pragma: no cover
     """Traverse meta objects and return the first pair of elements that are not equal."""
     res = None
     if type(x) != type(y):


### PR DESCRIPTION
Add a `make coverage` target that checks coverage differences between the current branch and `master`.  Also, ignore coverage on utility functions that interact with `pdb`.