### PR TITLE
Add ability to disable base object generation and use logic variable defaults

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -54,7 +54,6 @@ enable=import-error,
        unused-wildcard-import,
        global-variable-not-assigned,
        undefined-loop-variable,
-       global-statement,
        global-at-module-level,
        bad-open-mode,
        redundant-unittest-assert,
@@ -264,7 +263,7 @@ ignore-mixin-members=yes
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=tensorflow.core.framework,tensorflow.python.framework
+ignored-modules=tensorflow.core.framework,tensorflow.python.framework,tensorflow.python.ops.gen_linalg_ops
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set). This supports can work


### PR DESCRIPTION
Two context managers have been introduced:
  - `disable_auto_reification`: this prevents meta objects from creating base objects in order to determine undefined values (e.g. shapes, dtypes)
  - `enable_lvar_defaults`: this forces `symbolic-pymc` to use logic variables instead of default values (e.g. object names, `NodeDef.attr`).

This PR only adds the aforementioned functionality to the TensorFlow meta objects.