### PR TITLE
Extend TF meta object creation options to metatize

### DIFF
--- a/tests/tensorflow/test_meta.py
+++ b/tests/tensorflow/test_meta.py
@@ -579,3 +579,17 @@ def test_global_options():
         assert isvar(y_mt.op.node_def.attr)
         assert isvar(y_mt.op.inputs[0].op.node_def.attr)
         assert isvar(y_mt.op.inputs[1].op.node_def.attr)
+
+    with tf.Graph().as_default() as test_graph:
+        a_mt = mt(2.0)
+        assert a_mt.obj is not None
+
+    with test_graph.as_default(), enable_lvar_defaults('names', 'node_attrs'):
+        a_new_mt = mt(a_mt)
+        assert a_new_mt is a_mt
+
+        b_mt = 1.0 * a_mt
+        assert a_mt.obj is not None
+        assert isvar(b_mt.name)
+        assert isvar(b_mt.op.node_def.attr)
+        assert b_mt.op.inputs[1] is a_mt


### PR DESCRIPTION
These changes allow one to--for instance--create meta objects with logic variable names even when the objects are created through `metatize` (e.g. constant tensors).

Existing meta objects are also preserved--instead of recreated--when they're used as inputs to a meta object that's derived from a "temporary" base object (per `TFlowMetaOpDef.__call__`).

For example, without these changes, the following would succeed:
```python
import tensorflow as tf

from tensorflow.python.eager.context import graph_mode

from symbolic_pymc.tensorflow.meta import mt


with graph_mode():
    one_mt = mt(1.0)
    test_mt = mt.Add(one_mt, 2.0)

    assert test_mt.op.inputs[0] == one_mt
    assert test_mt.op.inputs[0] is not one_mt
```

Now, the last assertion will succeed with the `not` removed.