### PR TITLE
Make reify check for existing names in the current TensorFlow graph

### DIFF
--- a/symbolic_pymc/meta.py
+++ b/symbolic_pymc/meta.py
@@ -139,6 +139,12 @@ def meta_reify_iter(rands):
     return type(rands)(reified_rands), any_unreified
 
 
+class MetaReificationError(Exception):
+    """An exception type for errors encountered during the creation of base objects from meta objects."""
+
+    pass
+
+
 class MetaSymbolType(abc.ABCMeta):
     def __new__(cls, name, bases, clsdict):
 

--- a/symbolic_pymc/tensorflow/meta.py
+++ b/symbolic_pymc/tensorflow/meta.py
@@ -65,6 +65,20 @@ class MetaOpDefLibrary(object):
     }
     opdef_signatures = {}
 
+    def __init__(self):
+        #
+        # We need this in order to construct "Const" tensors directly, since
+        # the "value" attr in a meta `NodeDef` is just a NumPy array and not
+        # the `TensorProto` expected by `raw_ops.Const`.
+        #
+        def mt_const(value, dtype, name=None):
+            return tf.raw_ops.Const(
+                value=tensor_util.make_tensor_proto(value), dtype=dtype, name=name
+            )
+
+        opdef = op_def_registry.get("Const")
+        self.opdef_signatures[opdef.name] = self.make_opdef_sig(opdef, mt_const)
+
     @classmethod
     def get_op_info(cls, opdef):
         """Return the TF Python API function signature for a given `OpDef`.

--- a/tests/tensorflow/test_meta.py
+++ b/tests/tensorflow/test_meta.py
@@ -678,6 +678,21 @@ def test_global_options():
 
 
 @run_in_graph_mode
+def test_meta_const():
+    """Make sure we can create a Const tensor by hand."""
+
+    with tf.Graph().as_default():
+        one_mt = mt.const(1, 'int32', 'Const')
+
+    with tf.Graph().as_default():
+        another_one_mt = mt(1)
+
+    assert one_mt == another_one_mt
+    assert isinstance(one_mt.reify(), tf.Tensor)
+    assert one_mt.reify().op.type == 'Const'
+
+
+@run_in_graph_mode
 def test_meta_existing_names():
 
     with tf.Graph().as_default():


### PR DESCRIPTION
Now, when we reify TensorFlow meta objects, we check the current graph for any `Operation`s with the same name as the meta `Operation` being reified.  If there is such an `Operation` in the graph, we make sure it's equivalent to the meta `Operation` and return it if it is; otherwise, we throw a new `MetaReificationError`.

Also, this PR introduces a work-around for direct construction of constant tensors (e.g. `mt.const(1, 'int32', 'Const')`).  Previously, this was causing errors because the first argument (i.e. the `value` parameter) wasn't a `TensorProto` type.  We could simply carry around `TensorProto` typed values in the meta `NodeDef`, but that would cause other problems, so&mdash;instead&mdash;a wrapped version of the `tf.raw_ops.Const` function was added; it takes care of the conversion to `TensorProto`.