### PR TITLE
Fix unification for meta objects without properties

### DIFF
--- a/symbolic_pymc/unify.py
+++ b/symbolic_pymc/unify.py
@@ -46,7 +46,7 @@ def debug_unify(enable=True):  # pragma: no cover
 def unify_MetaSymbol(u, v, s):
     if type(u) != type(v):
         return False
-    if hasattr(u, "__all_props__"):
+    if getattr(u, "__all_props__", False):
         s = unify(
             [getattr(u, slot) for slot in u.__all_props__],
             [getattr(v, slot) for slot in v.__all_props__],

--- a/tests/tensorflow/test_meta.py
+++ b/tests/tensorflow/test_meta.py
@@ -567,7 +567,6 @@ def test_opdef_func():
     with tf.compat.v1.Session() as sess:
         assert sum_tf.eval() == np.r_[3]
 
-
 @run_in_graph_mode
 def test_tensor_ops():
 

--- a/tests/tensorflow/test_unify.py
+++ b/tests/tensorflow/test_unify.py
@@ -23,6 +23,9 @@ def test_operator():
 
     assert add_mt == mt.add
 
+    assert unify(mt.mul, mt.matmul) is False
+    assert unify(mt.mul.op_def, mt.matmul.op_def) is False
+
 
 @run_in_graph_mode
 def test_etuple_term():


### PR DESCRIPTION
Meta `OpDef`s, and the dependent `TFlowMetaOperator`s, were unifying when they shouldn't, because the `__all_props__` property was being checked for existence only.  When `__all_props__` was present and empty, `unify` would only compare empty sets and always succeed.