### PR TITLE
Fix PyMC3 RV Parameterizations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "scipy>=1.4.0",
         "Theano>=1.0.4",
         "tf-estimator-nightly==2.1.0.dev2020012309",
-        "tf-nightly==2.2.0.dev20200201",
+        "tf-nightly==2.2.0.dev20200301",
         "tfp-nightly==0.10.0.dev20200201",
         "multipledispatch>=0.6.0",
         "logical-unification>=0.4.3",

--- a/symbolic_pymc/theano/ops.py
+++ b/symbolic_pymc/theano/ops.py
@@ -306,8 +306,6 @@ class RandomVariable(tt.gof.Op):
         """Draw samples using Numpy/SciPy."""
         rng_out, smpl_out = outputs
 
-        # Draw from `rng` if `self.inplace` is `True`, and from a copy of `rng`
-        # otherwise.
         args = list(inputs)
         rng = args.pop()
         size = args.pop()
@@ -327,6 +325,8 @@ class RandomVariable(tt.gof.Op):
         else:
             size = tuple(size)
 
+        # Draw from `rng` if `self.inplace` is `True`, and from a copy of `rng`
+        # otherwise.
         if not self.inplace:
             rng = copy(rng)
 

--- a/symbolic_pymc/theano/pymc3.py
+++ b/symbolic_pymc/theano/pymc3.py
@@ -149,7 +149,7 @@ def _convert_rv_to_dist_MvNormal(op, rv):
 @convert_dist_to_rv.register(pm.Gamma, object)
 def convert_dist_to_rv_Gamma(dist, rng):
     size = dist.shape.astype(int)[GammaRV.ndim_supp :]
-    res = GammaRV(dist.alpha, tt.inv(dist.beta), size=size, rng=rng)
+    res = GammaRV(dist.alpha, dist.beta, size=size, rng=rng)
     return res
 
 
@@ -162,14 +162,13 @@ def _convert_rv_to_dist_Gamma(op, rv):
 @convert_dist_to_rv.register(pm.InverseGamma, object)
 def convert_dist_to_rv_InverseGamma(dist, rng):
     size = dist.shape.astype(int)[InvGammaRV.ndim_supp :]
-    res = InvGammaRV(dist.alpha, scale=dist.beta, size=size, rng=rng)
+    res = InvGammaRV(dist.alpha, rate=dist.beta, size=size, rng=rng)
     return res
 
 
 @_convert_rv_to_dist.register(InvGammaRVType, Apply)
 def _convert_rv_to_dist_InvGamma(op, rv):
-    assert not np.any(tt_get_values(rv.inputs[1]))
-    params = {"alpha": rv.inputs[0], "beta": rv.inputs[2]}
+    params = {"alpha": rv.inputs[0], "beta": rv.inputs[1]}
     return pm.InverseGamma, params
 
 


### PR DESCRIPTION
The SciPy `shape` parameter for the gamma types wasn't being used correctly in RV `Op.perform`.