### PR TITLE
Add a Theano Polya-Gamma random variable type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ python:
   # - "pypy3"
 
 install:
+  - pip install Cython
   - pip install -r requirements.txt
 
 script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ setuptools>=45.2.0
 six>=1.14.0
 -e ./
 sympy>=1.3
+pypolyagamma @ git+https://github.com/slinderman/pypolyagamma.git@b5883e661123862ca07d29ab14369fae85bdbc27#egg=pypolyagamma-1.2.2
 coveralls
 pydocstyle>=3.0.0
 pytest>=5.0.0


### PR DESCRIPTION
This is a very minimal implementation, and the sampler doesn't appear to interface, scale, or install well.  

At some point, it would be worthwhile to write a basic PG sampler that conforms to at least some SciPy standards (e.g. use Numpy/SciPy RNG objects, better use of `ndarray` objects from Cython/C++, low-level handling of broadcasting and flattening, etc.) and doesn't require an external package mostly comprised of unused features.