### PR TITLE
Introduce a function that converts RandomVariables to log-likelihoods

### DIFF
--- a/symbolic_pymc/theano/random_variables.py
+++ b/symbolic_pymc/theano/random_variables.py
@@ -447,11 +447,8 @@ class Observed(tt.Op):
             The distribution from which `val` is assumed to be a sample value.
         """
         val = tt.as_tensor_variable(val)
-        if rv:
-            if rv.owner and not isinstance(rv.owner.op, RandomVariable):
-                raise ValueError(f"`rv` must be a RandomVariable type: {rv}")
-
-            if rv.type.convert_variable(val) is None:
+        if rv is not None:
+            if not hasattr(rv, "type") or rv.type.convert_variable(val) is None:
                 raise ValueError(
                     ("`rv` and `val` do not have compatible types:" f" rv={rv}, val={val}")
                 )


### PR DESCRIPTION
This PR ties PyMC3's `Distribution.logp` functions to their corresponding `RandomVariable`s via a generic function `logp`.  The `logp` function will also compute log-likelihoods for `Scan`s that output `RandomVariable`s.