### PR TITLE
Introduce RandomVariable push-out optimization

### DIFF
--- a/symbolic_pymc/theano/pymc3.py
+++ b/symbolic_pymc/theano/pymc3.py
@@ -230,27 +230,27 @@ def _convert_rv_to_dist(op, rv):
 @convert_dist_to_rv.register(pm.Normal, object)
 def convert_dist_to_rv_Normal(dist, rng):
     size = dist.shape.astype(int)[NormalRV.ndim_supp :]
-    res = NormalRV(dist.mu, dist.sd, size=size, rng=rng)
+    res = NormalRV(dist.mu, dist.sigma, size=size, rng=rng)
     return res
 
 
 @_convert_rv_to_dist.register(NormalRVType, Apply)
 def _convert_rv_to_dist_Normal(op, rv):
-    params = {"mu": rv.inputs[0], "sd": rv.inputs[1]}
+    params = {"mu": rv.inputs[0], "sigma": rv.inputs[1]}
     return pm.Normal, params
 
 
 @convert_dist_to_rv.register(pm.HalfNormal, object)
 def convert_dist_to_rv_HalfNormal(dist, rng):
     size = dist.shape.astype(int)[HalfNormalRV.ndim_supp :]
-    res = HalfNormalRV(np.array(0.0, dtype=dist.dtype), dist.sd, size=size, rng=rng)
+    res = HalfNormalRV(np.array(0.0, dtype=dist.dtype), dist.sigma, size=size, rng=rng)
     return res
 
 
 @_convert_rv_to_dist.register(HalfNormalRVType, Apply)
 def _convert_rv_to_dist_HalfNormal(op, rv):
     assert not np.any(tt_get_values(rv.inputs[0]))
-    params = {"sd": rv.inputs[1]}
+    params = {"sigma": rv.inputs[1]}
     return pm.HalfNormal, params
 
 

--- a/symbolic_pymc/theano/pymc3.py
+++ b/symbolic_pymc/theano/pymc3.py
@@ -15,10 +15,13 @@ from warnings import warn
 from multipledispatch import dispatch
 from unification.utils import transitive_get as walk
 
+from theano.gof import Query
+from theano.compile import optdb
 from theano.gof.op import get_test_value
+from theano.gof.opt import SeqOptimizer, EquilibriumOptimizer
 from theano.gof.graph import Apply, inputs as tt_inputs
 from theano.scan_module.scan_op import Scan
-from theano.scan_module.scan_utils import clone
+from theano.scan_module.scan_utils import clone as tt_clone
 
 from .random_variables import (
     observed,
@@ -59,9 +62,15 @@ from .random_variables import (
     NegBinomialRV,
     NegBinomialRVType,
 )
-from .opt import FunctionGraph
 from .ops import RandomVariable
-from .utils import replace_input_nodes, get_rv_observation
+from .utils import (
+    replace_input_nodes,
+    get_rv_observation,
+    optimize_graph,
+    get_random_outer_outputs,
+    construct_scan,
+)
+from .opt import FunctionGraph, push_out_rvs_from_scan, convert_outer_out_to_in, ScanArgs
 
 logger = logging.getLogger("symbolic_pymc")
 
@@ -76,49 +85,6 @@ def tt_get_values(obj):
         raise TypeError(f"Unhandled observation type: {type(obj)}")
 
 
-@dispatch(Apply, object)
-def convert_rv_to_dist(node, obs):
-    if not isinstance(node.op, RandomVariable):
-        raise TypeError(f"{node} is not of type `RandomVariable`")
-
-    rv = node.default_output()
-
-    if hasattr(node, "fgraph") and hasattr(node.fgraph, "shape_feature"):
-        shape = list(node.fgraph.shape_feature.shape_tuple(rv))
-    else:
-        shape = list(rv.shape)
-
-    for i, s in enumerate(shape):
-        try:
-            shape[i] = tt.get_scalar_constant_value(s)
-        except tt.NotScalarConstantError:
-            shape[i] = s.tag.test_value
-
-    dist_type, dist_params = _convert_rv_to_dist(node.op, node)
-    return dist_type(rv.name, shape=shape, observed=obs, **dist_params)
-
-
-@dispatch(tt.TensorVariable, object)
-def logp(var, obs):
-
-    node = var.owner
-
-    if hasattr(node, "fgraph") and hasattr(node.fgraph, "shape_feature"):
-        shape = list(node.fgraph.shape_feature.shape_tuple(var))
-    else:
-        shape = list(var.shape)
-
-    for i, s in enumerate(shape):
-        try:
-            shape[i] = tt.get_scalar_constant_value(s)
-        except tt.NotScalarConstantError:
-            shape[i] = s.tag.test_value
-
-    logp_fn = _logp_fn(node.op, node, shape)
-    return logp_fn(obs)
-
-
-@dispatch(RandomVariable, Apply, object)
 def _logp_fn(op, node, shape=None):
     dist_type, dist_params = _convert_rv_to_dist(op, node)
     if shape is not None:
@@ -133,85 +99,129 @@ def _logp_fn(op, node, shape=None):
     return res.logp
 
 
-@_logp_fn.register(Scan, Apply, object)
-def _logp_fn_Scan(op, scan_node, shape=None):
+def create_inner_out_logp(input_scan_args, old_inner_out_var, new_inner_in_var, output_scan_args):
+    """Create a log-likelihood inner-output for a `Scan`."""
 
-    scan_inner_inputs = scan_node.op.inputs
-    scan_inner_outputs = scan_node.op.outputs
+    # shape = list(old_inner_out_var.owner.fgraph.shape_feature.shape_tuple(old_inner_out_var))
+    shape = None
+    logp_fn = _logp_fn(old_inner_out_var.owner.op, old_inner_out_var.owner, shape)
+    logp = logp_fn(new_inner_in_var)
+    if new_inner_in_var.name:
+        logp.name = "logp({})".format(new_inner_in_var.name)
+    return logp
 
-    def create_obs_var(i, x):
-        obs = x.type()
-        obs.name = f"{x.name or x.owner.op.name}_obs_{i}"
-        if hasattr(x.tag, "test_value"):
-            obs.tag.test_value = x.tag.test_value
-        return obs
 
-    rv_outs = [
-        (i, x, create_obs_var(i, x))
-        for i, x in enumerate(scan_inner_outputs)
-        if x.owner and isinstance(x.owner.op, RandomVariable)
-    ]
-    rv_inner_out_idx, rv_out_vars, rv_out_obs = zip(*rv_outs)
-    # rv_outer_out_idx = [scan_node.op.get_oinp_iinp_iout_oout_mappings()['outer_out_from_inner_out'][i] for i in rv_inner_out_idx]
-    # rv_outer_outputs = [scan_node.outputs[i] for i in rv_outer_out_idx]
+def logp(*output_vars):
+    """Compute the log-likelihood for a graph.
 
-    logp_inner_outputs = [clone(logp(rv, obs)) for i, rv, obs in rv_outs]
-    assert all(o in tt.gof.graph.inputs(logp_inner_outputs) for o in rv_out_obs)
+    Parameters
+    ----------
+    *output_vars: Tuple[TensorVariable]
+        The output of a graph containing `RandomVariable`s.
 
-    logp_inner_outputs_inputs = tt.gof.graph.inputs(logp_inner_outputs)
-    rv_relevant_inner_input_idx, rv_relevant_inner_inputs = zip(
-        *[(n, i) for n, i in enumerate(scan_inner_inputs) if i in logp_inner_outputs_inputs]
+    Results
+    -------
+    Dict[TensorVariable, TensorVariable]
+        A map from `RandomVariable`s to their log-likelihood graphs.
+
+    """
+    # model_inputs = [i for i in tt_inputs(output_vars) if not isinstance(i, tt.Constant)]
+    model_inputs = tt_inputs(output_vars)
+    model_fgraph = FunctionGraph(
+        model_inputs,
+        output_vars,
+        clone=True,
+        # XXX: `ShapeFeature` introduces cached constants
+        # features=[tt.opt.ShapeFeature()]
     )
-    logp_inner_inputs = list(rv_out_obs) + list(rv_relevant_inner_inputs)
 
-    # We need to create outer-inputs that represent arrays of observations
-    # for each random variable.
-    # To do that, we're going to use each random variable's outer-output term,
-    # since they necessarily have the same shape and type as the observations
-    # arrays.
+    canonicalize_opt = optdb.query(Query(include=["canonicalize"]))
+    push_out_opt = EquilibriumOptimizer([push_out_rvs_from_scan], max_use_ratio=10)
+    optimizations = SeqOptimizer(canonicalize_opt.copy())
+    optimizations.append(push_out_opt)
+    opt_fgraph = optimize_graph(model_fgraph, optimizations, in_place=True)
 
-    # Just like we did for the inner-inputs, we need to get only the outer-inputs
-    # that are relevant to the new logp graphs.
-    # We can do that by removing the irrelevant outer-inputs using the known relevant inner-inputs
-    removed_inner_inputs = set(range(len(scan_inner_inputs))) - set(rv_relevant_inner_input_idx)
-    old_in_out_mappings = scan_node.op.get_oinp_iinp_iout_oout_mappings()
-    rv_removed_outer_input_idx = [
-        old_in_out_mappings["outer_inp_from_inner_inp"][i] for i in removed_inner_inputs
-    ]
-    rv_removed_outer_inputs = [scan_node.inputs[i] for i in rv_removed_outer_input_idx]
+    replacements = {}
+    rv_to_logp_io = {}
+    for node in opt_fgraph.toposort():
+        # TODO: This `RandomVariable` "parsing" should be generalized and used
+        # in more places (e.g. what if the outer-outputs are `Subtensor`s)
+        if isinstance(node.op, RandomVariable):
+            var = node.default_output()
+            # shape = list(node.fgraph.shape_feature.shape_tuple(new_var))
+            shape = None
+            new_input_var = var.clone()
+            if new_input_var.name:
+                new_input_var.name = new_input_var.name.lower()
+            replacements[var] = new_input_var
+            rv_to_logp_io[var] = (new_input_var, _logp_fn(node.op, var.owner, shape)(new_input_var))
 
-    rv_relevant_outer_inputs = [r for r in scan_node.inputs if r not in rv_removed_outer_inputs]
+        if isinstance(node.op, tt.Subtensor) and node.inputs[0].owner:
+            # The output of `theano.scan` is sometimes a sliced tensor (in
+            # order to get rid of initial values introduced by in the `Scan`)
+            node = node.inputs[0].owner
 
-    # Now, we can create a new op with our new inner-graph inputs and outputs.
-    # Also, since our inner graph has new placeholder terms representing
-    # an observed value for each random variable, we need to update the
-    # "info" `dict`.
-    logp_info = scan_node.op.info.copy()
-    logp_info["tap_array"] = []
-    logp_info["n_seqs"] += len(rv_out_obs)
-    logp_info["n_mit_mot"] = 0
-    logp_info["n_mit_mot_outs"] = 0
-    logp_info["mit_mot_out_slices"] = []
-    logp_info["n_mit_sot"] = 0
-    logp_info["n_sit_sot"] = 0
-    logp_info["n_shared_outs"] = 0
-    logp_info["n_nit_sot"] += len(rv_out_obs) - 1
-    logp_info["name"] = None
-    logp_info["strict"] = True
+        if isinstance(node.op, Scan):
+            scan_args = ScanArgs.from_node(node)
+            rv_outer_outs = get_random_outer_outputs(scan_args)
 
-    # These are the tensor variables corresponding to each random variable's
-    # array of observations.
-    def logp_fn(*obs):
-        logp_obs_outer_inputs = list(obs)  # [r.clone() for r in rv_outer_outputs]
-        logp_outer_inputs = (
-            [rv_relevant_outer_inputs[0]] + logp_obs_outer_inputs + rv_relevant_outer_inputs[1:]
-        )
-        logp_op = Scan(logp_inner_inputs, logp_inner_outputs, logp_info)
-        scan_logp = logp_op(*logp_outer_inputs)
-        return scan_logp
+            for var_idx, var, io_var in rv_outer_outs:
+                scan_args, new_oi_var = convert_outer_out_to_in(
+                    scan_args, var, inner_out_fn=create_inner_out_logp, output_scan_args=scan_args
+                )
+                replacements[var] = new_oi_var
 
-    # logp_fn = OpFromGraph(logp_obs_outer_inputs, [scan_logp])
-    return logp_fn
+            logp_scan_out = construct_scan(scan_args)
+
+            for var_idx, var, io_var in rv_outer_outs:
+                rv_to_logp_io[var] = (replacements[var], logp_scan_out[var_idx])
+
+    # We need to use the new log-likelihood input variables that were generated
+    # for each `RandomVariable` node.  They need to replace the corresponding
+    # original variables within each log-likelihood graph.
+    rv_vars, inputs_logp_outputs = zip(*rv_to_logp_io.items())
+    new_inputs, logp_outputs = zip(*inputs_logp_outputs)
+
+    rev_memo = {v: k for k, v in model_fgraph.memo.items()}
+
+    # Replace the new cloned variables with the original ones, but only if
+    # they're not any of `RandomVariable` terms we've converted to
+    # log-likelihoods.
+    replacements.update(
+        {
+            k: v
+            for k, v in rev_memo.items()
+            if isinstance(k, tt.Variable) and v not in new_inputs and k not in replacements
+        }
+    )
+
+    new_logp_outputs = tt_clone(logp_outputs, replace=replacements)
+
+    rv_to_logp_io = {rev_memo[k]: v for k, v in zip(rv_vars, zip(new_inputs, new_logp_outputs))}
+
+    return rv_to_logp_io
+
+
+@dispatch(Apply, object)
+def convert_rv_to_dist(node, obs):
+    if not isinstance(node.op, RandomVariable):
+        raise TypeError(f"{node} is not of type `RandomVariable`")  # pragma: no cover
+
+    rv = node.default_output()
+
+    if hasattr(node, "fgraph") and hasattr(node.fgraph, "shape_feature"):
+        shape = list(node.fgraph.shape_feature.shape_tuple(rv))
+    else:
+        shape = list(rv.shape)
+
+    for i, s in enumerate(shape):
+        try:
+            shape[i] = tt.get_scalar_constant_value(s)
+        except tt.NotScalarConstantError:
+            shape[i] = get_test_value(s)
+
+    dist_type, dist_params = _convert_rv_to_dist(node.op, node)
+    return dist_type(rv.name, shape=shape, observed=obs, **dist_params)
 
 
 @dispatch(pm.Uniform, object)

--- a/symbolic_pymc/theano/utils.py
+++ b/symbolic_pymc/theano/utils.py
@@ -122,6 +122,7 @@ def optimize_graph(x, optimization, return_graph=None, in_place=False):
         res = x_graph_opt
     else:
         res = x_graph_opt.outputs
+        x_graph_opt.disown()
         if len(res) == 1:
             (res,) = res
     return res

--- a/tests/theano/test_opt.py
+++ b/tests/theano/test_opt.py
@@ -1,7 +1,9 @@
+import pytest
 import numpy as np
 import theano
 import theano.tensor as tt
 
+from copy import copy
 from unification import var
 
 from kanren import eq
@@ -18,6 +20,7 @@ from symbolic_pymc.theano.opt import (
     KanrenRelationSub,
     FunctionGraph,
     push_out_rvs_from_scan,
+    ScanArgs,
 )
 from symbolic_pymc.theano.utils import optimize_graph
 from symbolic_pymc.theano.random_variables import CategoricalRV, DirichletRV, NormalRV
@@ -137,3 +140,552 @@ def test_push_out_rvs():
     assert new_scan.op.outputs[0].owner.op == NormalRV
     assert new_scan.op.outputs[1].owner.op == CategoricalRV
     assert isinstance(new_scan.op.outputs[2].type, tt.raw_random.RandomStateType)
+
+
+def create_test_hmm():
+    rng_state = np.random.RandomState(np.random.MT19937(np.random.SeedSequence(1234)))
+    rng_tt = theano.shared(rng_state, name="rng", borrow=True)
+    rng_tt.tag.is_rng = True
+    rng_tt.default_update = rng_tt
+
+    N_tt = tt.iscalar("N")
+    N_tt.tag.test_value = 10
+    M_tt = tt.iscalar("M")
+    M_tt.tag.test_value = 2
+
+    mus_tt = tt.matrix("mus")
+    mus_tt.tag.test_value = np.stack([np.arange(0.0, 10), np.arange(0.0, -10, -1)], axis=-1).astype(
+        theano.config.floatX
+    )
+
+    sigmas_tt = tt.ones((N_tt,))
+    sigmas_tt.name = "sigmas"
+
+    pi_0_rv = DirichletRV(tt.ones((M_tt,)), rng=rng_tt, name="pi_0")
+    Gamma_rv = DirichletRV(tt.ones((M_tt, M_tt)), rng=rng_tt, name="Gamma")
+
+    S_0_rv = CategoricalRV(pi_0_rv, rng=rng_tt, name="S_0")
+
+    def scan_fn(mus_t, sigma_t, S_tm1, Gamma_t, rng):
+        S_t = CategoricalRV(Gamma_t[S_tm1], rng=rng, name="S_t")
+        Y_t = NormalRV(mus_t[S_t], sigma_t, rng=rng, name="Y_t")
+        return S_t, Y_t
+
+    (S_rv, Y_rv), scan_updates = theano.scan(
+        fn=scan_fn,
+        sequences=[mus_tt, sigmas_tt],
+        non_sequences=[Gamma_rv, rng_tt],
+        outputs_info=[{"initial": S_0_rv, "taps": [-1]}, {}],
+        strict=True,
+        name="scan_rv",
+    )
+    # Adding names should make output easier to read
+    Y_rv.name = "Y_rv"
+    # This `S_rv` outer-output is actually a `Subtensor` of the "real" output
+    S_rv = S_rv.owner.inputs[0]
+    S_rv.name = "S_rv"
+    rng_updates = scan_updates[rng_tt]
+    rng_updates.name = "rng_updates"
+    mus_in = Y_rv.owner.inputs[1]
+    mus_in.name = "mus_in"
+    sigmas_in = Y_rv.owner.inputs[2]
+    sigmas_in.name = "sigmas_in"
+
+    scan_op = Y_rv.owner.op
+    scan_args = ScanArgs.from_node(Y_rv.owner)
+
+    Gamma_in = scan_args.inner_in_non_seqs[0]
+    Y_t = scan_args.inner_out_nit_sot[0]
+    mus_t = scan_args.inner_in_seqs[0]
+    sigmas_t = scan_args.inner_in_seqs[1]
+    S_t = scan_args.inner_out_sit_sot[0]
+    rng_in = scan_args.inner_out_shared[0]
+
+    return locals()
+
+
+def test_ScanArgs_basics():
+    theano.config.cxx = ""
+    theano.config.mode = "FAST_COMPILE"
+    tt.config.compute_test_value = "warn"
+
+    # Make sure we can create an empty `ScanArgs`
+    scan_args = ScanArgs.create_empty()
+    assert scan_args.n_steps is None
+    for name in scan_args.field_names:
+        if name == "n_steps":
+            continue
+        assert len(getattr(scan_args, name)) == 0
+
+    with pytest.raises(TypeError):
+        ScanArgs.from_node(tt.ones(2).owner)
+
+    hmm_model_env = create_test_hmm()
+    scan_args = hmm_model_env["scan_args"]
+    scan_op = hmm_model_env["scan_op"]
+
+    # Make sure we can get alternate variables
+    test_v = scan_args.outer_out_sit_sot[0]
+    alt_test_v = scan_args.get_alt_field(test_v, "inner_out")
+    assert alt_test_v == scan_args.inner_out_sit_sot[0]
+
+    # Check the `__repr__` and `__str__`
+    scan_args_repr = repr(scan_args)
+    # Just make sure it doesn't err-out
+    assert scan_args_repr.startswith("ScanArgs")
+
+    # Check the properties that allow us to use
+    # `Scan.get_oinp_iinp_iout_oout_mappings` as-is to implement
+    # `ScanArgs.var_mappings`
+    assert scan_args.n_nit_sot == scan_op.n_nit_sot
+    assert scan_args.n_mit_mot == scan_op.n_mit_mot
+    # The `scan_args` base class always clones the inner-graph;
+    # here we make sure it doesn't (and that all the inputs are the same)
+    assert scan_args.inputs == scan_op.inputs
+    scan_op_info = dict(scan_op.info)
+    # The `ScanInfo` dictionary has the wrong order and an extra entry
+    del scan_op_info["strict"]
+    assert dict(scan_args.info) == scan_op_info
+    assert scan_args.var_mappings == scan_op.var_mappings
+
+    # Check that `ScanArgs.find_among_fields` works
+    test_v = scan_op.inner_seqs(scan_op.inputs)[1]
+    field_info = scan_args.find_among_fields(test_v)
+    assert field_info.name == "inner_in_seqs"
+    assert field_info.index == 1
+    assert field_info.inner_index is None
+    assert scan_args.inner_inputs[field_info.agg_index] == test_v
+
+    test_l = scan_op.inner_non_seqs(scan_op.inputs)
+    # We didn't index this argument, so it's a `list` (i.e. bad input)
+    field_info = scan_args.find_among_fields(test_l)
+    assert field_info is None
+
+    test_v = test_l[0]
+    field_info = scan_args.find_among_fields(test_v)
+    assert field_info.name == "inner_in_non_seqs"
+    assert field_info.index == 0
+    assert field_info.inner_index is None
+    assert scan_args.inner_inputs[field_info.agg_index] == test_v
+
+    scan_args_copy = copy(scan_args)
+    assert scan_args_copy is not scan_args
+    assert scan_args_copy == scan_args
+
+    assert scan_args_copy != test_v
+    scan_args_copy.outer_in_seqs.pop()
+    assert scan_args_copy != scan_args
+
+
+def test_ScanArgs_basics_mit_sot():
+    theano.config.cxx = ""
+    theano.config.mode = "FAST_COMPILE"
+    tt.config.compute_test_value = "warn"
+
+    rng_state = np.random.RandomState(np.random.MT19937(np.random.SeedSequence(1234)))
+    rng_tt = theano.shared(rng_state, name="rng", borrow=True)
+    rng_tt.tag.is_rng = True
+    rng_tt.default_update = rng_tt
+
+    N_tt = tt.iscalar("N")
+    N_tt.tag.test_value = 10
+    M_tt = tt.iscalar("M")
+    M_tt.tag.test_value = 2
+
+    mus_tt = tt.matrix("mus")
+    mus_tt.tag.test_value = np.stack([np.arange(0.0, 10), np.arange(0.0, -10, -1)], axis=-1).astype(
+        theano.config.floatX
+    )
+
+    sigmas_tt = tt.ones((N_tt,))
+    sigmas_tt.name = "sigmas"
+
+    pi_0_rv = DirichletRV(tt.ones((M_tt,)), rng=rng_tt, name="pi_0")
+    Gamma_rv = DirichletRV(tt.ones((M_tt, M_tt)), rng=rng_tt, name="Gamma")
+
+    S_0_rv = CategoricalRV(pi_0_rv, rng=rng_tt, name="S_0")
+
+    def scan_fn(mus_t, sigma_t, S_tm2, S_tm1, Gamma_t, rng):
+        S_t = CategoricalRV(Gamma_t[S_tm2], rng=rng, name="S_t")
+        Y_t = NormalRV(mus_t[S_tm1], sigma_t, rng=rng, name="Y_t")
+        return S_t, Y_t
+
+    (S_rv, Y_rv), scan_updates = theano.scan(
+        fn=scan_fn,
+        sequences=[mus_tt, sigmas_tt],
+        non_sequences=[Gamma_rv, rng_tt],
+        outputs_info=[{"initial": tt.stack([S_0_rv, S_0_rv]), "taps": [-2, -1]}, {}],
+        strict=True,
+        name="scan_rv",
+    )
+    # Adding names should make output easier to read
+    Y_rv.name = "Y_rv"
+    # This `S_rv` outer-output is actually a `Subtensor` of the "real" output
+    S_rv = S_rv.owner.inputs[0]
+    S_rv.name = "S_rv"
+    rng_updates = scan_updates[rng_tt]
+    rng_updates.name = "rng_updates"
+    mus_in = Y_rv.owner.inputs[1]
+    mus_in.name = "mus_in"
+    sigmas_in = Y_rv.owner.inputs[2]
+    sigmas_in.name = "sigmas_in"
+
+    scan_args = ScanArgs.from_node(Y_rv.owner)
+
+    test_v = scan_args.inner_in_mit_sot[0][1]
+    field_info = scan_args.find_among_fields(test_v)
+
+    assert field_info.name == "inner_in_mit_sot"
+    assert field_info.index == 0
+    assert field_info.inner_index == 1
+    assert field_info.agg_index == 3
+
+    rm_info = scan_args._remove_from_fields(tt.ones(2))
+    assert rm_info is None
+
+    rm_info = scan_args._remove_from_fields(test_v)
+
+    assert rm_info.name == "inner_in_mit_sot"
+    assert rm_info.index == 0
+    assert rm_info.inner_index == 1
+    assert rm_info.agg_index == 3
+
+
+def test_ScanArgs_remove_inner_input():
+    theano.config.cxx = ""
+    theano.config.mode = "FAST_COMPILE"
+    tt.config.compute_test_value = "warn"
+
+    hmm_model_env = create_test_hmm()
+    scan_args = hmm_model_env["scan_args"]
+    scan_op = hmm_model_env["scan_op"]
+    Y_t = hmm_model_env["Y_t"]
+    Y_rv = hmm_model_env["Y_rv"]
+    sigmas_in = hmm_model_env["sigmas_in"]
+    sigmas_t = hmm_model_env["sigmas_t"]
+    Gamma_rv = hmm_model_env["Gamma_rv"]
+    Gamma_in = hmm_model_env["Gamma_in"]
+    S_rv = hmm_model_env["S_rv"]
+    S_t = hmm_model_env["S_t"]
+    rng_tt = hmm_model_env["rng_tt"]
+    rng_in = hmm_model_env["rng_in"]
+    rng_updates = hmm_model_env["rng_updates"]
+
+    # Check `ScanArgs.remove_from_fields` by removing `sigmas[t]` (i.e. the
+    # inner-graph input)
+    scan_args_copy = copy(scan_args)
+    test_v = sigmas_t
+
+    rm_info = scan_args_copy.remove_from_fields(test_v, rm_dependents=False)
+    removed_nodes, _ = zip(*rm_info)
+
+    assert sigmas_t in removed_nodes
+    assert sigmas_t not in scan_args_copy.inner_in_seqs
+    assert Y_t not in removed_nodes
+    assert len(scan_args_copy.inner_out_nit_sot) == 1
+
+    scan_args_copy = copy(scan_args)
+    test_v = sigmas_t
+
+    # This removal includes dependents
+    rm_info = scan_args_copy.remove_from_fields(test_v, rm_dependents=True)
+    removed_nodes, _ = zip(*rm_info)
+
+    # `sigmas[t]` (i.e. inner-graph input) should be gone
+    assert sigmas_t in removed_nodes
+    assert sigmas_t not in scan_args_copy.inner_in_seqs
+    # `Y_t` (i.e. inner-graph output) should be gone
+    assert Y_t in removed_nodes
+    assert len(scan_args_copy.inner_out_nit_sot) == 0
+    # `Y_rv` (i.e. outer-graph output) should be gone
+    assert Y_rv in removed_nodes
+    assert Y_rv not in scan_args_copy.outer_outputs
+    assert len(scan_args_copy.outer_out_nit_sot) == 0
+    # `sigmas_in` (i.e. outer-graph input) should be gone
+    assert sigmas_in in removed_nodes
+    assert test_v not in scan_args_copy.inner_in_seqs
+
+    # These shouldn't have been removed
+    assert S_t in scan_args_copy.inner_out_sit_sot
+    assert S_rv in scan_args_copy.outer_out_sit_sot
+    assert Gamma_in in scan_args_copy.inner_in_non_seqs
+    assert Gamma_rv in scan_args_copy.outer_in_non_seqs
+    assert rng_tt in scan_args_copy.outer_in_shared
+    assert rng_in in scan_args_copy.inner_out_shared
+    assert rng_updates in scan_args.outer_out_shared
+
+    # The other `Y_rv`-related inputs currently aren't removed, even though
+    # they're no longer needed.
+    # TODO: Would be nice if we did this, too
+    # assert len(scan_args_copy.outer_in_seqs) == 0
+    # TODO: Would be nice if we did this, too
+    # assert len(scan_args_copy.inner_in_seqs) == 0
+
+    # We shouldn't be able to remove the removed node
+    with pytest.raises(ValueError):
+        rm_info = scan_args_copy.remove_from_fields(test_v, rm_dependents=True)
+
+
+def test_ScanArgs_remove_outer_input():
+    theano.config.cxx = ""
+    theano.config.mode = "FAST_COMPILE"
+    tt.config.compute_test_value = "warn"
+
+    hmm_model_env = create_test_hmm()
+    scan_args = hmm_model_env["scan_args"]
+    scan_op = hmm_model_env["scan_op"]
+    Y_t = hmm_model_env["Y_t"]
+    Y_rv = hmm_model_env["Y_rv"]
+    sigmas_in = hmm_model_env["sigmas_in"]
+    sigmas_t = hmm_model_env["sigmas_t"]
+    Gamma_rv = hmm_model_env["Gamma_rv"]
+    Gamma_in = hmm_model_env["Gamma_in"]
+    S_rv = hmm_model_env["S_rv"]
+    S_t = hmm_model_env["S_t"]
+    rng_tt = hmm_model_env["rng_tt"]
+    rng_in = hmm_model_env["rng_in"]
+    rng_updates = hmm_model_env["rng_updates"]
+
+    # Remove `sigmas` (i.e. the outer-input)
+    scan_args_copy = copy(scan_args)
+    test_v = sigmas_in
+    rm_info = scan_args_copy.remove_from_fields(test_v, rm_dependents=True)
+    removed_nodes, _ = zip(*rm_info)
+
+    # `sigmas_in` (i.e. outer-graph input) should be gone
+    assert scan_args.outer_in_seqs[-1] in removed_nodes
+    assert test_v not in scan_args_copy.inner_in_seqs
+
+    # `sigmas[t]` should be gone
+    assert sigmas_t in removed_nodes
+    assert sigmas_t not in scan_args_copy.inner_in_seqs
+
+    # `Y_t` (i.e. inner-graph output) should be gone
+    assert Y_t in removed_nodes
+    assert len(scan_args_copy.inner_out_nit_sot) == 0
+
+    # `Y_rv` (i.e. outer-graph output) should be gone
+    assert Y_rv not in scan_args_copy.outer_outputs
+    assert len(scan_args_copy.outer_out_nit_sot) == 0
+
+    assert S_t in scan_args_copy.inner_out_sit_sot
+    assert S_rv in scan_args_copy.outer_out_sit_sot
+    assert Gamma_in in scan_args_copy.inner_in_non_seqs
+    assert Gamma_rv in scan_args_copy.outer_in_non_seqs
+    assert rng_tt in scan_args_copy.outer_in_shared
+    assert rng_in in scan_args_copy.inner_out_shared
+    assert rng_updates in scan_args.outer_out_shared
+
+
+def test_ScanArgs_remove_inner_output():
+    theano.config.cxx = ""
+    theano.config.mode = "FAST_COMPILE"
+    tt.config.compute_test_value = "warn"
+
+    hmm_model_env = create_test_hmm()
+    scan_args = hmm_model_env["scan_args"]
+    scan_op = hmm_model_env["scan_op"]
+    Y_t = hmm_model_env["Y_t"]
+    Y_rv = hmm_model_env["Y_rv"]
+    sigmas_in = hmm_model_env["sigmas_in"]
+    sigmas_t = hmm_model_env["sigmas_t"]
+    Gamma_rv = hmm_model_env["Gamma_rv"]
+    Gamma_in = hmm_model_env["Gamma_in"]
+    S_rv = hmm_model_env["S_rv"]
+    S_t = hmm_model_env["S_t"]
+    rng_tt = hmm_model_env["rng_tt"]
+    rng_in = hmm_model_env["rng_in"]
+    rng_updates = hmm_model_env["rng_updates"]
+
+    # Remove `Y_t` (i.e. the inner-output)
+    scan_args_copy = copy(scan_args)
+    test_v = Y_t
+    rm_info = scan_args_copy.remove_from_fields(test_v, rm_dependents=True)
+    removed_nodes, _ = zip(*rm_info)
+
+    # `Y_t` (i.e. inner-graph output) should be gone
+    assert Y_t in removed_nodes
+    assert len(scan_args_copy.inner_out_nit_sot) == 0
+
+    # `Y_rv` (i.e. outer-graph output) should be gone
+    assert Y_rv not in scan_args_copy.outer_outputs
+    assert len(scan_args_copy.outer_out_nit_sot) == 0
+
+    assert S_t in scan_args_copy.inner_out_sit_sot
+    assert S_rv in scan_args_copy.outer_out_sit_sot
+    assert Gamma_in in scan_args_copy.inner_in_non_seqs
+    assert Gamma_rv in scan_args_copy.outer_in_non_seqs
+    assert rng_tt in scan_args_copy.outer_in_shared
+    assert rng_in in scan_args_copy.inner_out_shared
+    assert rng_updates in scan_args.outer_out_shared
+
+
+def test_ScanArgs_remove_outer_output():
+    theano.config.cxx = ""
+    theano.config.mode = "FAST_COMPILE"
+    tt.config.compute_test_value = "warn"
+
+    hmm_model_env = create_test_hmm()
+    scan_args = hmm_model_env["scan_args"]
+    scan_op = hmm_model_env["scan_op"]
+    Y_t = hmm_model_env["Y_t"]
+    Y_rv = hmm_model_env["Y_rv"]
+    sigmas_in = hmm_model_env["sigmas_in"]
+    sigmas_t = hmm_model_env["sigmas_t"]
+    Gamma_rv = hmm_model_env["Gamma_rv"]
+    Gamma_in = hmm_model_env["Gamma_in"]
+    S_rv = hmm_model_env["S_rv"]
+    S_t = hmm_model_env["S_t"]
+    rng_tt = hmm_model_env["rng_tt"]
+    rng_in = hmm_model_env["rng_in"]
+    rng_updates = hmm_model_env["rng_updates"]
+
+    # Remove `Y_rv` (i.e. a nit-sot outer-output)
+    scan_args_copy = copy(scan_args)
+    test_v = Y_rv
+    rm_info = scan_args_copy.remove_from_fields(test_v, rm_dependents=True)
+    removed_nodes, _ = zip(*rm_info)
+
+    # `Y_t` (i.e. inner-graph output) should be gone
+    assert Y_t in removed_nodes
+    assert len(scan_args_copy.inner_out_nit_sot) == 0
+
+    # `Y_rv` (i.e. outer-graph output) should be gone
+    assert Y_rv not in scan_args_copy.outer_outputs
+    assert len(scan_args_copy.outer_out_nit_sot) == 0
+
+    assert S_t in scan_args_copy.inner_out_sit_sot
+    assert S_rv in scan_args_copy.outer_out_sit_sot
+    assert Gamma_in in scan_args_copy.inner_in_non_seqs
+    assert Gamma_rv in scan_args_copy.outer_in_non_seqs
+    assert rng_tt in scan_args_copy.outer_in_shared
+    assert rng_in in scan_args_copy.inner_out_shared
+    assert rng_updates in scan_args.outer_out_shared
+
+
+def test_ScanArgs_remove_nonseq_outer_input():
+    theano.config.cxx = ""
+    theano.config.mode = "FAST_COMPILE"
+    tt.config.compute_test_value = "warn"
+
+    hmm_model_env = create_test_hmm()
+    scan_args = hmm_model_env["scan_args"]
+    scan_op = hmm_model_env["scan_op"]
+    Y_t = hmm_model_env["Y_t"]
+    Y_rv = hmm_model_env["Y_rv"]
+    mus_in = hmm_model_env["mus_in"]
+    mus_t = hmm_model_env["mus_t"]
+    sigmas_in = hmm_model_env["sigmas_in"]
+    sigmas_t = hmm_model_env["sigmas_t"]
+    Gamma_rv = hmm_model_env["Gamma_rv"]
+    Gamma_in = hmm_model_env["Gamma_in"]
+    S_rv = hmm_model_env["S_rv"]
+    S_t = hmm_model_env["S_t"]
+    rng_tt = hmm_model_env["rng_tt"]
+    rng_in = hmm_model_env["rng_in"]
+    rng_updates = hmm_model_env["rng_updates"]
+
+    # Remove `Gamma` (i.e. a non-sequence outer-input)
+    scan_args_copy = copy(scan_args)
+    test_v = Gamma_rv
+    rm_info = scan_args_copy.remove_from_fields(test_v, rm_dependents=True)
+    removed_nodes, _ = zip(*rm_info)
+
+    assert Gamma_rv in removed_nodes
+    assert Gamma_in in removed_nodes
+    assert S_rv in removed_nodes
+    assert S_t in removed_nodes
+    assert Y_t in removed_nodes
+    assert Y_rv in removed_nodes
+
+    assert mus_in in scan_args_copy.outer_in_seqs
+    assert sigmas_in in scan_args_copy.outer_in_seqs
+    assert mus_t in scan_args_copy.inner_in_seqs
+    assert sigmas_t in scan_args_copy.inner_in_seqs
+    assert rng_tt in scan_args_copy.outer_in_shared
+    assert rng_in in scan_args_copy.inner_out_shared
+    assert rng_updates in scan_args.outer_out_shared
+
+
+def test_ScanArgs_remove_nonseq_inner_input():
+    theano.config.cxx = ""
+    theano.config.mode = "FAST_COMPILE"
+    tt.config.compute_test_value = "warn"
+
+    hmm_model_env = create_test_hmm()
+    scan_args = hmm_model_env["scan_args"]
+    scan_op = hmm_model_env["scan_op"]
+    Y_t = hmm_model_env["Y_t"]
+    Y_rv = hmm_model_env["Y_rv"]
+    mus_in = hmm_model_env["mus_in"]
+    mus_t = hmm_model_env["mus_t"]
+    sigmas_in = hmm_model_env["sigmas_in"]
+    sigmas_t = hmm_model_env["sigmas_t"]
+    Gamma_rv = hmm_model_env["Gamma_rv"]
+    Gamma_in = hmm_model_env["Gamma_in"]
+    S_rv = hmm_model_env["S_rv"]
+    S_t = hmm_model_env["S_t"]
+    rng_tt = hmm_model_env["rng_tt"]
+    rng_in = hmm_model_env["rng_in"]
+    rng_updates = hmm_model_env["rng_updates"]
+
+    # Remove `Gamma` (i.e. a non-sequence inner-input)
+    scan_args_copy = copy(scan_args)
+    test_v = Gamma_in
+    rm_info = scan_args_copy.remove_from_fields(test_v, rm_dependents=True)
+    removed_nodes, _ = zip(*rm_info)
+
+    assert Gamma_in in removed_nodes
+    assert Gamma_rv in removed_nodes
+    assert S_rv in removed_nodes
+    assert S_t in removed_nodes
+
+    # import pdb; pdb.set_trace()
+
+    assert mus_in in scan_args_copy.outer_in_seqs
+    assert sigmas_in in scan_args_copy.outer_in_seqs
+    assert mus_t in scan_args_copy.inner_in_seqs
+    assert sigmas_t in scan_args_copy.inner_in_seqs
+    assert rng_tt in scan_args_copy.outer_in_shared
+    assert rng_in in scan_args_copy.inner_out_shared
+    assert rng_updates in scan_args.outer_out_shared
+
+
+def test_ScanArgs_remove_shared_inner_output():
+    theano.config.cxx = ""
+    theano.config.mode = "FAST_COMPILE"
+    tt.config.compute_test_value = "warn"
+
+    hmm_model_env = create_test_hmm()
+    scan_args = hmm_model_env["scan_args"]
+    scan_op = hmm_model_env["scan_op"]
+    Y_t = hmm_model_env["Y_t"]
+    Y_rv = hmm_model_env["Y_rv"]
+    mus_in = hmm_model_env["mus_in"]
+    mus_t = hmm_model_env["mus_t"]
+    sigmas_in = hmm_model_env["sigmas_in"]
+    sigmas_t = hmm_model_env["sigmas_t"]
+    Gamma_rv = hmm_model_env["Gamma_rv"]
+    Gamma_in = hmm_model_env["Gamma_in"]
+    S_rv = hmm_model_env["S_rv"]
+    S_t = hmm_model_env["S_t"]
+    rng_tt = hmm_model_env["rng_tt"]
+    rng_in = hmm_model_env["rng_in"]
+    rng_updates = hmm_model_env["rng_updates"]
+
+    # Remove `rng` (i.e. a shared inner-output)
+    scan_args_copy = copy(scan_args)
+    test_v = rng_updates
+    rm_info = scan_args_copy.remove_from_fields(test_v, rm_dependents=True)
+    removed_nodes, _ = zip(*rm_info)
+
+    assert rng_tt in removed_nodes
+    assert rng_in in removed_nodes
+    assert rng_updates in removed_nodes
+    assert Y_rv in removed_nodes
+    assert S_rv in removed_nodes
+
+    assert sigmas_in in scan_args_copy.outer_in_seqs
+    assert sigmas_t in scan_args_copy.inner_in_seqs
+    assert mus_in in scan_args_copy.outer_in_seqs
+    assert mus_t in scan_args_copy.inner_in_seqs

--- a/tests/theano/test_opt.py
+++ b/tests/theano/test_opt.py
@@ -1,3 +1,5 @@
+import numpy as np
+import theano
 import theano.tensor as tt
 
 from unification import var
@@ -9,10 +11,16 @@ from etuples import etuple, etuplize
 
 from theano.gof.opt import EquilibriumOptimizer
 from theano.gof.graph import inputs as tt_inputs
+from theano.scan_module.scan_op import Scan
 
 from symbolic_pymc.theano.meta import mt
-from symbolic_pymc.theano.opt import KanrenRelationSub, FunctionGraph
+from symbolic_pymc.theano.opt import (
+    KanrenRelationSub,
+    FunctionGraph,
+    push_out_rvs_from_scan,
+)
 from symbolic_pymc.theano.utils import optimize_graph
+from symbolic_pymc.theano.random_variables import CategoricalRV, DirichletRV, NormalRV
 
 
 def test_kanren_opt():
@@ -58,3 +66,74 @@ def test_kanren_opt():
     assert fgraph_opt.owner.inputs[1].owner.op == tt.add
     assert isinstance(fgraph_opt.owner.inputs[1].owner.inputs[0].owner.op, tt.Dot)
     assert isinstance(fgraph_opt.owner.inputs[1].owner.inputs[1].owner.op, tt.Dot)
+
+
+def test_push_out_rvs():
+    theano.config.cxx = ""
+    theano.config.mode = "FAST_COMPILE"
+    tt.config.compute_test_value = "warn"
+
+    rng_state = np.random.RandomState(np.random.MT19937(np.random.SeedSequence(1234)))
+    rng_tt = theano.shared(rng_state, name="rng", borrow=True)
+    rng_tt.tag.is_rng = True
+    rng_tt.default_update = rng_tt
+
+    N_tt = tt.iscalar("N")
+    N_tt.tag.test_value = 10
+    M_tt = tt.iscalar("M")
+    M_tt.tag.test_value = 2
+
+    mus_tt = tt.matrix("mus_t")
+    mus_tt.tag.test_value = np.stack([np.arange(0.0, 10), np.arange(0.0, -10, -1)], axis=-1).astype(
+        theano.config.floatX
+    )
+
+    sigmas_tt = tt.ones((N_tt,))
+    Gamma_rv = DirichletRV(tt.ones((M_tt, M_tt)), rng=rng_tt, name="Gamma")
+
+    # The optimizer should do nothing to this term, because it's not a `Scan`
+    fgraph = FunctionGraph(tt_inputs([Gamma_rv]), [Gamma_rv])
+    pushoutrvs_opt = EquilibriumOptimizer([push_out_rvs_from_scan], max_use_ratio=10)
+    Gamma_opt_rv = optimize_graph(fgraph, pushoutrvs_opt, return_graph=False)
+    # The `FunctionGraph` will, however, clone the graph objects, so we can't
+    # simply check that `gamma_opt_rv == Gamma_rv`
+    assert all(type(a) == type(b) for a, b in zip(tt_inputs([Gamma_rv]), tt_inputs([Gamma_opt_rv])))
+    assert theano.scan_module.scan_utils.equal_computations(
+        [Gamma_opt_rv], [Gamma_rv], tt_inputs([Gamma_opt_rv]), tt_inputs([Gamma_rv])
+    )
+
+    # In this case, `Y_t` depends on `S_t` and `S_t` is not output.  Our
+    # push-out optimization should create a new `Scan` that also outputs each
+    # `S_t`.
+    def scan_fn(mus_t, sigma_t, Gamma_t, rng):
+        S_t = CategoricalRV(Gamma_t[0], rng=rng, name="S_t")
+        Y_t = NormalRV(mus_t[S_t], sigma_t, rng=rng, name="Y_t")
+        return Y_t
+
+    Y_rv, _ = theano.scan(
+        fn=scan_fn,
+        sequences=[mus_tt, sigmas_tt],
+        non_sequences=[Gamma_rv, rng_tt],
+        outputs_info=[{}],
+        strict=True,
+        name="scan_rv",
+    )
+    Y_rv.name = "Y_rv"
+
+    orig_scan_op = Y_rv.owner.op
+    assert len(Y_rv.owner.outputs) == 2
+    assert isinstance(orig_scan_op, Scan)
+    assert len(orig_scan_op.outputs) == 2
+    assert orig_scan_op.outputs[0].owner.op == NormalRV
+    assert isinstance(orig_scan_op.outputs[1].type, tt.raw_random.RandomStateType)
+
+    fgraph = FunctionGraph(tt_inputs([Y_rv]), [Y_rv], clone=True)
+    fgraph_opt = optimize_graph(fgraph, pushoutrvs_opt, return_graph=True)
+
+    # There should now be a new output for all the `S_t`
+    new_scan = fgraph_opt.outputs[0].owner
+    assert len(new_scan.outputs) == 3
+    assert isinstance(new_scan.op, Scan)
+    assert new_scan.op.outputs[0].owner.op == NormalRV
+    assert new_scan.op.outputs[1].owner.op == CategoricalRV
+    assert isinstance(new_scan.op.outputs[2].type, tt.raw_random.RandomStateType)

--- a/tests/theano/test_pymc3.py
+++ b/tests/theano/test_pymc3.py
@@ -21,10 +21,9 @@ from symbolic_pymc.theano.utils import canonicalize
 from symbolic_pymc.theano.meta import mt
 
 
+@theano.change_flags(compute_test_value="ignore", cxx="")
 def test_pymc3_convert_dists():
     """Just a basic check that all PyMC3 RVs will convert to and from Theano RVs."""
-    tt.config.compute_test_value = "ignore"
-    theano.config.cxx = ""
 
     with pm.Model() as model:
         norm_rv = pm.Normal("norm_rv", 0.0, 1.0, observed=1.0)
@@ -67,9 +66,9 @@ def test_pymc3_convert_dists():
     assert res.vars[0].name == "normal_0"
 
 
+@theano.change_flags(compute_test_value="ignore")
 def test_pymc3_normal_model():
     """Conduct a more in-depth test of PyMC3/Theano conversions for a specific model."""
-    tt.config.compute_test_value = "ignore"
 
     mu_X = tt.dscalar("mu_X")
     sd_X = tt.dscalar("sd_X")
@@ -80,10 +79,10 @@ def test_pymc3_normal_model():
 
     # We need something that uses transforms...
     with pm.Model() as model:
-        X_rv = pm.Normal("X_rv", mu_X, sd=sd_X)
+        X_rv = pm.Normal("X_rv", mu_X, sigma=sd_X)
         S_rv = pm.HalfCauchy("S_rv", beta=np.array(0.5, dtype=tt.config.floatX))
-        Y_rv = pm.Normal("Y_rv", X_rv * S_rv, sd=S_rv)
-        Z_rv = pm.Normal("Z_rv", X_rv + Y_rv, sd=sd_X, observed=10.0)
+        Y_rv = pm.Normal("Y_rv", X_rv * S_rv, sigma=S_rv)
+        Z_rv = pm.Normal("Z_rv", X_rv + Y_rv, sigma=sd_X, observed=10.0)
 
     fgraph = model_graph(model, output_vars=[Z_rv])
 
@@ -146,9 +145,9 @@ def test_pymc3_normal_model():
     assert all(v == 1 for v in Z_vars_count.values())
 
 
+@theano.change_flags(compute_test_value="ignore")
 def test_normals_to_model():
     """Test conversion to a PyMC3 model."""
-    tt.config.compute_test_value = "ignore"
 
     a_tt = tt.vector("a")
     R_tt = tt.matrix("R")
@@ -211,9 +210,9 @@ def test_normals_to_model():
         model = graph_model(Y_obs)
 
 
+@theano.change_flags(compute_test_value="ignore")
 def test_pymc3_broadcastable():
     """Test PyMC3 to Theano conversion amid array broadcasting."""
-    tt.config.compute_test_value = "ignore"
 
     mu_X = tt.vector("mu_X")
     sd_X = tt.vector("sd_X")
@@ -225,9 +224,9 @@ def test_pymc3_broadcastable():
     sd_Y.tag.test_value = np.array([0.5], dtype=tt.config.floatX)
 
     with pm.Model() as model:
-        X_rv = pm.Normal("X_rv", mu_X, sd=sd_X, shape=(1,))
-        Y_rv = pm.Normal("Y_rv", mu_Y, sd=sd_Y, shape=(1,))
-        Z_rv = pm.Normal("Z_rv", X_rv + Y_rv, sd=sd_X + sd_Y, shape=(1,), observed=[10.0])
+        X_rv = pm.Normal("X_rv", mu_X, sigma=sd_X, shape=(1,))
+        Y_rv = pm.Normal("Y_rv", mu_Y, sigma=sd_Y, shape=(1,))
+        Z_rv = pm.Normal("Z_rv", X_rv + Y_rv, sigma=sd_X + sd_Y, shape=(1,), observed=[10.0])
 
     with pytest.warns(UserWarning):
         fgraph = model_graph(model)

--- a/tests/theano/test_utils.py
+++ b/tests/theano/test_utils.py
@@ -1,0 +1,21 @@
+import theano
+
+from symbolic_pymc.theano.utils import is_random_variable
+from symbolic_pymc.theano.random_variables import NormalRV
+
+
+@theano.change_flags(compute_test_value="ignore", cxx="")
+def test_is_random_variable():
+
+    X_rv = NormalRV(0, 1)
+    res = is_random_variable(X_rv)
+    assert res == (X_rv, X_rv)
+
+    def scan_fn():
+        Y_t = NormalRV(0, 1, name="Y_t")
+        return Y_t
+
+    Y_rv, scan_updates = theano.scan(fn=scan_fn, outputs_info=[{}], n_steps=10,)
+
+    res = is_random_variable(Y_rv)
+    assert res == (Y_rv, Y_rv.owner.op.outputs[0])

--- a/tests/theano/utils.py
+++ b/tests/theano/utils.py
@@ -1,0 +1,71 @@
+import numpy as np
+import theano
+import theano.tensor as tt
+
+from symbolic_pymc.theano.opt import ScanArgs
+from symbolic_pymc.theano.random_variables import CategoricalRV, DirichletRV, NormalRV
+
+
+def create_test_hmm():
+    rng_state = np.random.RandomState(np.random.MT19937(np.random.SeedSequence(1234)))
+    rng_init_state = rng_state.get_state()
+    rng_tt = theano.shared(rng_state, name="rng", borrow=True)
+    rng_tt.tag.is_rng = True
+    rng_tt.default_update = rng_tt
+
+    N_tt = tt.iscalar("N")
+    N_tt.tag.test_value = 10
+    M_tt = tt.iscalar("M")
+    M_tt.tag.test_value = 2
+
+    mus_tt = tt.matrix("mus")
+    mus_tt.tag.test_value = np.stack([np.arange(0.0, 10), np.arange(0.0, -10, -1)], axis=-1).astype(
+        theano.config.floatX
+    )
+
+    sigmas_tt = tt.ones((N_tt,))
+    sigmas_tt.name = "sigmas"
+
+    pi_0_rv = DirichletRV(tt.ones((M_tt,)), rng=rng_tt, name="pi_0")
+    Gamma_rv = DirichletRV(tt.ones((M_tt, M_tt)), rng=rng_tt, name="Gamma")
+
+    S_0_rv = CategoricalRV(pi_0_rv, rng=rng_tt, name="S_0")
+
+    def scan_fn(mus_t, sigma_t, S_tm1, Gamma_t, rng):
+        S_t = CategoricalRV(Gamma_t[S_tm1], rng=rng, name="S_t")
+        Y_t = NormalRV(mus_t[S_t], sigma_t, rng=rng, name="Y_t")
+        return S_t, Y_t
+
+    (S_rv, Y_rv), scan_updates = theano.scan(
+        fn=scan_fn,
+        sequences=[mus_tt, sigmas_tt],
+        non_sequences=[Gamma_rv, rng_tt],
+        outputs_info=[{"initial": S_0_rv, "taps": [-1]}, {}],
+        strict=True,
+        name="scan_rv",
+    )
+    Y_rv.name = "Y_rv"
+
+    scan_op = Y_rv.owner.op
+    scan_args = ScanArgs.from_node(Y_rv.owner)
+
+    Gamma_in = scan_args.inner_in_non_seqs[0]
+    Y_t = scan_args.inner_out_nit_sot[0]
+    mus_t = scan_args.inner_in_seqs[0]
+    sigmas_t = scan_args.inner_in_seqs[1]
+    S_t = scan_args.inner_out_sit_sot[0]
+    rng_in = scan_args.inner_out_shared[0]
+
+    rng_updates = scan_updates[rng_tt]
+    rng_updates.name = "rng_updates"
+    mus_in = Y_rv.owner.inputs[1]
+    mus_in.name = "mus_in"
+    sigmas_in = Y_rv.owner.inputs[2]
+    sigmas_in.name = "sigmas_in"
+
+    # The output `S_rv` is really `S_rv[1:]`, so we have to extract the actual
+    # `Scan` output: `S_rv`.
+    S_in = S_rv.owner.inputs[0]
+    S_in.name = "S_in"
+
+    return locals()


### PR DESCRIPTION
This PR introduces the steps necessary for computing log-likelihood graphs across a much wider variety of `Scan`-induced random variables/distributions.