### PR TITLE
Make DirichletRV and CategoricalRV parameters broadcastable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pytest>=5.0.0
 pytest-cov>=2.6.1
 pytest-html>=1.20.0
 pylint>=2.3.1
-black>=19.3b0; platform.python_implementation!='PyPy'
+black==20.8b1; platform.python_implementation!='PyPy'
 diff-cover
 ipython
 versioneer

--- a/symbolic_pymc/theano/random_variables.py
+++ b/symbolic_pymc/theano/random_variables.py
@@ -115,7 +115,12 @@ class MvNormalRVType(RandomVariable):
 
     def __init__(self):
         super().__init__(
-            "multivariate_normal", theano.config.floatX, 1, [1, 2], self._smpl_fn, inplace=True,
+            "multivariate_normal",
+            theano.config.floatX,
+            1,
+            [1, 2],
+            self._smpl_fn,
+            inplace=True,
         )
 
     @classmethod
@@ -376,7 +381,12 @@ class CategoricalRVType(RandomVariable):
 
     def __init__(self):
         super().__init__(
-            "categorical", "int64", 0, [1], sample_categorical, inplace=True,
+            "categorical",
+            "int64",
+            0,
+            [1],
+            sample_categorical,
+            inplace=True,
         )
 
     def make_node(self, pvals, size=None, rng=None, name=None):
@@ -397,7 +407,12 @@ class PolyaGammaRVType(RandomVariable):
 
     def __init__(self):
         super().__init__(
-            "polya-gamma", theano.config.floatX, 0, [0, 0], self._smpl_fn, inplace=True,
+            "polya-gamma",
+            theano.config.floatX,
+            0,
+            [0, 0],
+            self._smpl_fn,
+            inplace=True,
         )
 
     def make_node(self, b, c, size=None, rng=None, name=None):

--- a/tests/theano/test_opt.py
+++ b/tests/theano/test_opt.py
@@ -31,8 +31,7 @@ from tests.theano.utils import create_test_hmm
 
 @theano.change_flags(compute_test_value="ignore", cxx="", mode="FAST_COMPILE")
 def test_kanren_opt():
-    """Make sure we can run miniKanren "optimizations" over a graph until a fixed-point/normal-form is reached.
-    """
+    """Make sure we can run miniKanren "optimizations" over a graph until a fixed-point/normal-form is reached."""
     x_tt = tt.vector("x")
     c_tt = tt.vector("c")
     d_tt = tt.vector("c")
@@ -740,7 +739,9 @@ def test_convert_outer_out_to_in_mit_sot():
 
     Y_rv, _ = theano.scan(
         fn=input_step_fn,
-        outputs_info=[{"initial": tt.as_tensor_variable(np.r_[-1.0, 0.0]), "taps": [-1, -2]},],
+        outputs_info=[
+            {"initial": tt.as_tensor_variable(np.r_[-1.0, 0.0]), "taps": [-1, -2]},
+        ],
         non_sequences=[rng_tt],
         n_steps=10,
     )

--- a/tests/theano/test_utils.py
+++ b/tests/theano/test_utils.py
@@ -15,7 +15,11 @@ def test_is_random_variable():
         Y_t = NormalRV(0, 1, name="Y_t")
         return Y_t
 
-    Y_rv, scan_updates = theano.scan(fn=scan_fn, outputs_info=[{}], n_steps=10,)
+    Y_rv, scan_updates = theano.scan(
+        fn=scan_fn,
+        outputs_info=[{}],
+        n_steps=10,
+    )
 
     res = is_random_variable(Y_rv)
     assert res == (Y_rv, Y_rv.owner.op.outputs[0])


### PR DESCRIPTION
This PR fixes broadcast issues involving `DirichletRV`, `CategoricalRV`, their distribution parameters and the `size` keyword.  Basically, SciPy/NumPy's Dirichlet and categorical-like sampling functions don't broadcast, so we have to implement it ourselves.